### PR TITLE
Fix TAILi instruction and collatz test

### DIFF
--- a/assembly/src/emulator.rs
+++ b/assembly/src/emulator.rs
@@ -824,7 +824,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: Fix test, see #6.
     fn test_compiled_collatz() {
         //     collatz:
         //     ;; Frame:
@@ -994,8 +993,14 @@ mod tests {
         let mut cur_val = initial_val;
 
         for i in 0..nb_frames {
-            assert!(traces.vrom.get_u32(i as u32 * 16 + 4) == ((i + 1) * 16) as u32);
-            assert_eq!(traces.vrom.get_u32(i as u32 * 16 + 2), cur_val);
+            assert_eq!(
+                traces.vrom.get_u32((i as u32 * 16 + 4) * 4), // next_fp
+                ((i + 1) * 16 * 4) as u32                     // next_fp_val
+            );
+            assert_eq!(
+                traces.vrom.get_u32((i as u32 * 16 + 2) * 4), // n
+                cur_val                                       // n_val
+            );
 
             if cur_val % 2 == 0 {
                 cur_val /= 2;

--- a/assembly/src/event/call.rs
+++ b/assembly/src/event/call.rs
@@ -52,8 +52,11 @@ impl TailiEvent {
         let next_fp_val = interpreter
             .vrom
             .get_u32(interpreter.fp ^ next_fp.val() as u32);
+
         let pc = interpreter.pc;
+        let fp = interpreter.fp;
         let timestamp = interpreter.timestamp;
+
         interpreter.fp = next_fp_val;
         interpreter.jump_to(target);
 
@@ -62,7 +65,7 @@ impl TailiEvent {
 
         Self {
             pc,
-            fp: interpreter.fp,
+            fp,
             timestamp,
             target: target.val(),
             next_fp: next_fp.val(),


### PR DESCRIPTION
TAILi event `fp` was not being set before updating the interpreter's related field, messing up with the state channels being unbalanced between MVV.W pushes and TAILI pulls.

Also fix the collatz unit test.