### PR TITLE
Add some debugging info

### DIFF
--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -8,8 +8,11 @@ thiserror = "2.0.11"
 num_enum = "=0.5.3"
 binius_field.workspace = true
 binius_utils.workspace = true
+env_logger = "0.11.6"
 pest = "2.7.15"
 pest_derive = "2.7.15"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
When debugging #20, I realized we were missing some basic tracing for execution / channel flushes making it hard to track where issues come from.

This is a very basic start, logging execution steps, and upon unbalanced state channel, displaying all remaining flushes (ordered by timestamp).

closes #18