### PR TITLE
Type-check FP

### DIFF
--- a/assembly/src/event/binary_ops/b128.rs
+++ b/assembly/src/event/binary_ops/b128.rs
@@ -5,7 +5,8 @@ use crate::{
     define_bin128_op_event,
     event::{context::EventContext, Event},
     execution::{
-        Interpreter, InterpreterChannels, InterpreterError, InterpreterTables, ZCrayTrace, G,
+        FramePointer, Interpreter, InterpreterChannels, InterpreterError, InterpreterTables,
+        ZCrayTrace, G,
     },
 };
 

--- a/assembly/src/event/binary_ops/b32.rs
+++ b/assembly/src/event/binary_ops/b32.rs
@@ -102,7 +102,7 @@ define_bin32_op_event!(
 pub(crate) struct B32MuliEvent {
     timestamp: u32,
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     dst: u16,
     dst_val: u32,
     src: u16,
@@ -171,10 +171,10 @@ impl Event for B32MuliEvent {
 
         channels
             .state_channel
-            .pull((self.pc, self.fp, self.timestamp));
+            .pull((self.pc, *self.fp, self.timestamp));
         channels
             .state_channel
-            .push((self.pc * G * G, self.fp, self.timestamp));
+            .push((self.pc * G * G, *self.fp, self.timestamp));
     }
 }
 

--- a/assembly/src/event/binary_ops/mod.rs
+++ b/assembly/src/event/binary_ops/mod.rs
@@ -3,7 +3,10 @@ use core::fmt::Debug;
 use binius_field::{BinaryField16b, BinaryField32b};
 
 use super::context::EventContext;
-use crate::{execution::InterpreterError, ZCrayTrace};
+use crate::{
+    execution::{FramePointer, InterpreterError},
+    ZCrayTrace,
+};
 
 pub(crate) mod b128;
 pub(crate) mod b32;
@@ -37,7 +40,7 @@ pub(crate) trait ImmediateBinaryOperation:
     fn new(
         timestamp: u32,
         pc: BinaryField32b,
-        fp: u32,
+        fp: FramePointer,
         dst: u16,
         dst_val: u32,
         src: u16,
@@ -76,7 +79,7 @@ pub(crate) trait NonImmediateBinaryOperation:
     fn new(
         timestamp: u32,
         pc: BinaryField32b,
-        fp: u32,
+        fp: FramePointer,
         dst: u16,
         dst_val: u32,
         src1: u16,

--- a/assembly/src/event/branch.rs
+++ b/assembly/src/event/branch.rs
@@ -3,7 +3,8 @@ use binius_field::{BinaryField16b, BinaryField32b, ExtensionField};
 use super::{context::EventContext, Event};
 use crate::{
     execution::{
-        Interpreter, InterpreterChannels, InterpreterError, InterpreterTables, ZCrayTrace,
+        FramePointer, Interpreter, InterpreterChannels, InterpreterError, InterpreterTables,
+        ZCrayTrace,
     },
     fire_non_jump_event,
 };
@@ -19,7 +20,7 @@ use crate::{
 pub(crate) struct BnzEvent {
     timestamp: u32,
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     cond: u16,
     con_val: u32,
     target: BinaryField32b,
@@ -59,10 +60,10 @@ impl Event for BnzEvent {
         assert_ne!(self.cond, 0);
         channels
             .state_channel
-            .pull((self.pc, self.fp, self.timestamp));
+            .pull((self.pc, *self.fp, self.timestamp));
         channels
             .state_channel
-            .push((self.target, self.fp, self.timestamp));
+            .push((self.target, *self.fp, self.timestamp));
     }
 }
 
@@ -71,7 +72,7 @@ impl Event for BnzEvent {
 pub(crate) struct BzEvent {
     timestamp: u32,
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     cond: u16,
     cond_val: u32,
     target: BinaryField32b,

--- a/assembly/src/event/context.rs
+++ b/assembly/src/event/context.rs
@@ -22,11 +22,10 @@ pub(crate) struct EventContext<'a> {
 }
 
 impl EventContext<'_> {
-    // TODO: merge with #70 if it goes through
     /// Computes a VROM address from a provided offset, by scaling the frame
     /// pointer accordingly.
     pub fn addr(&self, offset: impl Into<u32>) -> u32 {
-        self.fp ^ offset.into()
+        *self.fp ^ offset.into()
     }
 
     /// Loads a `u32` value stored in VROM at the provided address.

--- a/assembly/src/event/integer_ops.rs
+++ b/assembly/src/event/integer_ops.rs
@@ -9,7 +9,8 @@ use crate::{
     define_bin32_imm_op_event, define_bin32_op_event,
     event::{binary_ops::*, Event},
     execution::{
-        Interpreter, InterpreterChannels, InterpreterError, InterpreterTables, ZCrayTrace,
+        FramePointer, Interpreter, InterpreterChannels, InterpreterError, InterpreterTables,
+        ZCrayTrace,
     },
     fire_non_jump_event, impl_binary_operation, impl_event_for_binary_operation,
     impl_immediate_binary_operation, Opcode,
@@ -115,7 +116,7 @@ define_bin32_op_event!(
 #[derive(Debug, Clone)]
 pub(crate) struct MuliEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,
     dst_val: u64,
@@ -174,7 +175,7 @@ impl Event for MuliEvent {
 #[derive(Debug, Clone)]
 pub(crate) struct MuluEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,
     dst_val: u64,
@@ -456,7 +457,7 @@ impl_generic_signed_mul_event!(Mulsu, MulsuEvent);
 #[derive(Debug, Clone)]
 pub(crate) struct SignedMulEvent<SignedMulOperation> {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,
     dst_val: u64,

--- a/assembly/src/event/jump.rs
+++ b/assembly/src/event/jump.rs
@@ -2,7 +2,9 @@ use binius_field::{BinaryField16b, BinaryField32b, ExtensionField};
 
 use super::{context::EventContext, Event};
 use crate::{
-    execution::{Interpreter, InterpreterChannels, InterpreterError, InterpreterTables},
+    execution::{
+        FramePointer, Interpreter, InterpreterChannels, InterpreterError, InterpreterTables,
+    },
     ZCrayTrace,
 };
 
@@ -15,7 +17,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub(crate) struct JumpvEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     offset: u16,
     target: u32,
@@ -51,10 +53,10 @@ impl Event for JumpvEvent {
     fn fire(&self, channels: &mut InterpreterChannels, _tables: &InterpreterTables) {
         channels
             .state_channel
-            .pull((self.pc, self.fp, self.timestamp));
+            .pull((self.pc, *self.fp, self.timestamp));
         channels
             .state_channel
-            .push((BinaryField32b::new(self.target), self.fp, self.timestamp));
+            .push((BinaryField32b::new(self.target), *self.fp, self.timestamp));
     }
 }
 
@@ -67,7 +69,7 @@ impl Event for JumpvEvent {
 #[derive(Debug, Clone)]
 pub(crate) struct JumpiEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     target: BinaryField32b,
 }
@@ -102,10 +104,10 @@ impl Event for JumpiEvent {
     fn fire(&self, channels: &mut InterpreterChannels, _tables: &InterpreterTables) {
         channels
             .state_channel
-            .pull((self.pc, self.fp, self.timestamp));
+            .pull((self.pc, *self.fp, self.timestamp));
         channels.state_channel.push((
             BinaryField32b::new(self.target.val()),
-            self.fp,
+            *self.fp,
             self.timestamp,
         ));
     }

--- a/assembly/src/event/macros.rs
+++ b/assembly/src/event/macros.rs
@@ -8,7 +8,7 @@ macro_rules! impl_binary_operation {
             fn new(
                 timestamp: u32,
                 pc: BinaryField32b,
-                fp: u32,
+                fp: FramePointer,
                 dst: u16,
                 dst_val: u32,
                 src1: u16,
@@ -116,10 +116,10 @@ macro_rules! fire_non_jump_event {
     ($intrp:ident, $channels:ident) => {
         $channels
             .state_channel
-            .pull(($intrp.pc, $intrp.fp, $intrp.timestamp));
+            .pull(($intrp.pc, *$intrp.fp, $intrp.timestamp));
         $channels.state_channel.push((
             $intrp.pc * $crate::execution::G,
-            $intrp.fp,
+            *$intrp.fp,
             $intrp.timestamp,
         ));
     };
@@ -133,7 +133,7 @@ macro_rules! impl_immediate_binary_operation {
             fn new(
                 timestamp: u32,
                 pc: BinaryField32b,
-                fp: u32,
+                fp: FramePointer,
                 dst: u16,
                 dst_val: u32,
                 src: u16,
@@ -164,7 +164,7 @@ macro_rules! impl_32b_immediate_binary_operation {
             const fn new(
                 timestamp: u32,
                 pc: BinaryField32b,
-                fp: u32,
+                fp: FramePointer,
                 dst: u16,
                 dst_val: u32,
                 src: u16,
@@ -194,7 +194,7 @@ macro_rules! define_bin32_op_event {
         pub(crate) struct $name {
             pub(crate) timestamp: u32,
             pub(crate) pc: BinaryField32b,
-            pub(crate) fp: u32,
+            pub(crate) fp: FramePointer,
             pub(crate) dst: u16,
             pub(crate) dst_val: u32,
             pub(crate) src1: u16,
@@ -223,7 +223,7 @@ macro_rules! define_bin32_imm_op_event {
         pub(crate) struct $name {
             pub(crate) timestamp: u32,
             pub(crate) pc: BinaryField32b,
-            pub(crate) fp: u32,
+            pub(crate) fp: FramePointer,
             pub(crate) dst: u16,
             pub(crate) dst_val: u32,
             pub(crate) src: u16,
@@ -251,7 +251,7 @@ macro_rules! define_bin128_op_event {
         pub(crate) struct $name {
             timestamp: u32,
             pc: BinaryField32b,
-            fp: u32,
+            fp: FramePointer,
             dst: u16,
             dst_val: u128,
             src1: u16,
@@ -328,10 +328,10 @@ macro_rules! define_bin128_op_event {
                 assert_eq!(self.output(), Self::operation(self.left(), self.right()));
 
                 // Update state channel
-                channels.state_channel.pull((self.pc, self.fp, self.timestamp));
+                channels.state_channel.pull((self.pc, *self.fp, self.timestamp));
                 channels
                     .state_channel
-                    .push((self.pc * G, self.fp, self.timestamp));
+                    .push((self.pc * G, *self.fp, self.timestamp));
             }
         }
     };

--- a/assembly/src/event/mv.rs
+++ b/assembly/src/event/mv.rs
@@ -4,7 +4,8 @@ use super::context::EventContext;
 use crate::{
     event::Event,
     execution::{
-        Interpreter, InterpreterChannels, InterpreterError, InterpreterTables, ZCrayTrace,
+        FramePointer, Interpreter, InterpreterChannels, InterpreterError, InterpreterTables,
+        ZCrayTrace,
     },
     fire_non_jump_event,
     memory::MemoryError,
@@ -57,7 +58,7 @@ pub(crate) struct MVEventOutput {
     pub(crate) parent: u32, // parent addr
     pub(crate) opcode: Opcode,
     pub(crate) field_pc: BinaryField32b, // field PC
-    pub(crate) fp: u32,                  // fp
+    pub(crate) fp: FramePointer,         // fp
     pub(crate) timestamp: u32,           // timestamp
     pub(crate) dst: BinaryField16b,      // dst
     pub(crate) src: BinaryField16b,      // src
@@ -71,7 +72,7 @@ impl MVEventOutput {
         parent: u32, // parent addr
         opcode: Opcode,
         field_pc: BinaryField32b, // field PC
-        fp: u32,                  // fp
+        fp: FramePointer,         // fp
         timestamp: u32,           // timestamp
         dst: BinaryField16b,      // dst
         src: BinaryField16b,      // src
@@ -145,7 +146,7 @@ impl MVEventOutput {
 #[derive(Debug, Clone)]
 pub(crate) struct MVVWEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,
     dst_addr: u32,
@@ -160,7 +161,7 @@ impl MVVWEvent {
     #[allow(clippy::too_many_arguments)]
     pub const fn new(
         pc: BinaryField32b,
-        fp: u32,
+        fp: FramePointer,
         timestamp: u32,
         dst: u16,
         dst_addr: u32,
@@ -186,7 +187,7 @@ impl MVVWEvent {
         ctx: &mut EventContext,
         pc: BinaryField32b,
         timestamp: u32,
-        fp: u32,
+        fp: FramePointer,
         dst: BinaryField16b,
         offset: BinaryField16b,
         src: BinaryField16b,
@@ -218,7 +219,7 @@ impl MVVWEvent {
             // also set the value at `src_addr` and generate the MOVE event.
             ctx.trace.insert_pending(
                 dst_addr ^ offset.val() as u32,
-                (src_addr, Opcode::Mvvw, pc, fp, timestamp, dst, src, offset),
+                (src_addr, Opcode::Mvvw, pc, *fp, timestamp, dst, src, offset),
             );
             Ok(None)
         }
@@ -286,7 +287,7 @@ impl_mv_event!(MVVWEvent, mvvw);
 #[derive(Debug, Clone)]
 pub(crate) struct MVVLEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,
     dst_addr: u32,
@@ -299,7 +300,7 @@ impl MVVLEvent {
     #[allow(clippy::too_many_arguments)]
     pub const fn new(
         pc: BinaryField32b,
-        fp: u32,
+        fp: FramePointer,
         timestamp: u32,
         dst: u16,
         dst_addr: u32,
@@ -325,7 +326,7 @@ impl MVVLEvent {
         ctx: &mut EventContext,
         pc: BinaryField32b,
         timestamp: u32,
-        fp: u32,
+        fp: FramePointer,
         dst: BinaryField16b,
         offset: BinaryField16b,
         src: BinaryField16b,
@@ -357,7 +358,7 @@ impl MVVLEvent {
             // also set the value at `src_addr` and generate the MOVE event.
             ctx.trace.insert_pending(
                 dst_addr ^ offset.val() as u32,
-                (src_addr, Opcode::Mvvl, pc, fp, timestamp, dst, src, offset),
+                (src_addr, Opcode::Mvvl, pc, *fp, timestamp, dst, src, offset),
             );
             Ok(None)
         }
@@ -424,7 +425,7 @@ impl_mv_event!(MVVLEvent, mvvl);
 #[derive(Debug, Clone)]
 pub(crate) struct MVIHEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,
     dst_addr: u32,
@@ -441,7 +442,7 @@ impl MVIHEvent {
         ctx: &mut EventContext,
         pc: BinaryField32b,
         timestamp: u32,
-        fp: u32,
+        fp: FramePointer,
         dst: BinaryField16b,
         offset: BinaryField16b,
         imm: BinaryField16b,
@@ -514,7 +515,7 @@ impl_mv_event!(MVIHEvent, mvih);
 #[derive(Debug, Clone)]
 pub(crate) struct LDIEvent {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,
     imm: u32,

--- a/assembly/src/event/shift.rs
+++ b/assembly/src/event/shift.rs
@@ -6,7 +6,9 @@ use binius_field::{BinaryField16b, BinaryField32b, Field};
 use super::context::EventContext;
 use crate::{
     event::{binary_ops::*, Event},
-    execution::{Interpreter, InterpreterChannels, InterpreterError, InterpreterTables},
+    execution::{
+        FramePointer, Interpreter, InterpreterChannels, InterpreterError, InterpreterTables,
+    },
     fire_non_jump_event, Opcode, ZCrayTrace,
 };
 
@@ -87,7 +89,7 @@ where
     O: ShiftOperation<S> + Send + Sync + 'static,
 {
     pc: BinaryField32b,
-    fp: u32,
+    fp: FramePointer,
     timestamp: u32,
     dst: u16,                // 16-bit destination VROM offset
     dst_val: u32,            // 32-bit result value
@@ -104,7 +106,7 @@ where
 {
     pub const fn new(
         pc: BinaryField32b,
-        fp: u32,
+        fp: FramePointer,
         timestamp: u32,
         dst: u16,
         dst_val: u32,

--- a/assembly/src/execution/channels.rs
+++ b/assembly/src/execution/channels.rs
@@ -14,7 +14,7 @@ pub struct Channel<T> {
 
 pub(crate) type PromChannel = Channel<(u32, u128)>; // PC, opcode, args (so 64 bits overall).
 pub(crate) type VromChannel = Channel<u32>;
-pub(crate) type StateChannel = Channel<(BinaryField32b, u32, u32)>; // PC, FP, Timestamp
+pub(crate) type StateChannel = Channel<(BinaryField32b, u32, u32)>; // pc, *fp, timestamp
 
 impl<T: Hash + Eq + Debug> Channel<T> {
     pub(crate) fn push(&mut self, val: T) {

--- a/assembly/src/execution/trace.rs
+++ b/assembly/src/execution/trace.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use binius_field::{BinaryField32b, Field, PackedField};
 
+use super::FramePointer;
 #[cfg(test)]
 use crate::memory::VromPendingUpdates;
 use crate::{
@@ -74,7 +75,7 @@ pub struct ZCrayTrace {
 
 pub struct BoundaryValues {
     pub(crate) final_pc: BinaryField32b,
-    pub(crate) final_fp: u32,
+    pub(crate) final_fp: FramePointer,
     pub(crate) timestamp: u32,
 }
 
@@ -134,7 +135,7 @@ impl ZCrayTrace {
         // Final boundary pull.
         channels.state_channel.pull((
             boundary_values.final_pc,
-            boundary_values.final_fp,
+            *boundary_values.final_fp,
             boundary_values.timestamp,
         ));
 
@@ -190,7 +191,7 @@ impl ZCrayTrace {
                     parent,
                     opcode,
                     field_pc,
-                    fp,
+                    fp.into(),
                     timestamp,
                     dst,
                     src,
@@ -216,7 +217,7 @@ impl ZCrayTrace {
                     parent,
                     opcode,
                     field_pc,
-                    fp,
+                    fp.into(),
                     timestamp,
                     dst,
                     src,
@@ -239,7 +240,15 @@ impl ZCrayTrace {
                 let (parent, opcode, field_pc, fp, timestamp, dst, src, offset) = pending_update;
                 self.set_vrom_u128(parent, value)?;
                 let event_out = MVEventOutput::new(
-                    parent, opcode, field_pc, fp, timestamp, dst, src, offset, value,
+                    parent,
+                    opcode,
+                    field_pc,
+                    fp.into(),
+                    timestamp,
+                    dst,
+                    src,
+                    offset,
+                    value,
                 );
                 event_out.push_mv_event(self);
             }


### PR DESCRIPTION
I initially wanted to type-check FP and PC, and add some helper methods especially given that we call often `interpreter.fp ^ offset` to get some address), and that for PC, we do a lot of weird-looking manipulations and switches between field / int type that seem risky and error-prone.

~I'm not super happy with how this refactoring ends up looking for PC, so I wouldn't object closing it but opening in case it gives others some ideas to handle this. Ideally:~

- ~we wouldn't have to think too much about the underlying PC type (is it `u32`? is it `B32`?)~
- ~we would abstract all PC manipulations (+1 / *G) behind some common `incr()` method~

~Note if you're actively reviewing it: it is verbose because of the renaming `field_pc -> pc` and `pc -> int_pc` which I find semantically more accurate, given the integer value is a helper view but the actual PC as per the design is the actual field value.~