### PR TITLE
Fixed ASM parser error output being thrown away

### DIFF
--- a/assembly/src/parser/instructions_with_labels.rs
+++ b/assembly/src/parser/instructions_with_labels.rs
@@ -309,5 +309,5 @@ pub enum Error {
     NoStartLabelOrInstructionFound,
 
     #[error(transparent)]
-    PestParseError(#[from] pest::error::Error<super::Rule>),
+    PestParse(#[from] Box<pest::error::Error<super::Rule>>),
 }

--- a/assembly/src/parser/mod.rs
+++ b/assembly/src/parser/mod.rs
@@ -408,7 +408,7 @@ pub fn parse_program(input: &str) -> Result<Vec<InstructionsWithLabels>, Error> 
     let mut instrs = Vec::<InstructionsWithLabels>::new();
 
     let program = parser
-        .map_err(Error::PestParseError)?
+        .map_err(|err| Error::PestParse(Box::new(err)))?
         .next()
         .ok_or(Error::NoStartLabelOrInstructionFound)?
         .into_inner();


### PR DESCRIPTION
When parsing the ASM, if there was a PEST parsing error, we were just discarding it. I introduced a new error type that holds a PEST parsing error if one occurs.