### PR TITLE
Fix vrom addr space size

### DIFF
--- a/prover/src/circuit.rs
+++ b/prover/src/circuit.rs
@@ -103,7 +103,10 @@ impl Circuit {
 
         let prom_size = trace.program.len();
 
-        let vrom_addr_space_size = trace.max_vrom_addr.next_power_of_two();
+        // By adding 1 to `max_vrom_addr`, `next_power_of_two()` will advance to the
+        // next power of two even when `max_vrom_addr` is already a power of two,
+        // ensuring the VROM address space includes the highest address.
+        let vrom_addr_space_size = (trace.max_vrom_addr + 1).next_power_of_two();
 
         // VROM write size is the number of addresses we write to
         let vrom_write_size = trace.vrom_writes.len();

--- a/prover/tests/simple.rs
+++ b/prover/tests/simple.rs
@@ -154,7 +154,8 @@ fn generate_add_ret_trace(src1_value: u32, src2_value: u32) -> Result<Trace> {
          _start: 
             LDI.W @2, #{}\n\
             LDI.W @3, #{}\n\
-            ADD @4, @2, @3\n\
+            ;; Skip @4 to test a gap in vrom writes
+            ADD @5, @2, @3\n\
             RET\n",
         src1_value, src2_value
     );
@@ -168,7 +169,7 @@ fn generate_add_ret_trace(src1_value: u32, src2_value: u32) -> Result<Trace> {
         (0, 0, 1),
         (1, 0, 1),
         // ADD event
-        (4, src1_value + src2_value, 1),
+        (5, src1_value + src2_value, 1),
     ];
 
     generate_trace(asm_code, None, Some(vrom_writes))


### PR DESCRIPTION
This also fixes `cargo run --example collatz -- --n 1`