### PR TITLE
Cleanup deadcode in `assembly` crate

### DIFF
--- a/assembly/src/event/branch.rs
+++ b/assembly/src/event/branch.rs
@@ -94,10 +94,10 @@ pub struct BzEvent {
 
 impl Event for BzEvent {
     fn generate(
-        ctx: &mut EventContext,
-        target_low: B16,
-        target_high: B16,
-        cond: B16,
+        _ctx: &mut EventContext,
+        _target_low: B16,
+        _target_high: B16,
+        _cond: B16,
     ) -> Result<(), InterpreterError> {
         unimplemented!("BzEvent generation is defined in BnzEvent::generate method");
     }

--- a/assembly/src/event/comparison.rs
+++ b/assembly/src/event/comparison.rs
@@ -3,11 +3,8 @@ use binius_m3::builder::{B16, B32};
 use super::context::EventContext;
 use crate::{
     define_bin32_imm_op_event, define_bin32_op_event,
-    event::{binary_ops::*, Event},
-    execution::{FramePointer, InterpreterChannels, InterpreterError},
-    fire_non_jump_event,
-    gadgets::Add64Gadget,
-    Opcode,
+    event::binary_ops::*,
+    execution::{FramePointer, InterpreterError},
 };
 
 // Note: The addition is checked thanks to the ADD32 table.
@@ -121,7 +118,7 @@ define_bin32_imm_op_event!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{execution::Interpreter, get_last_event, ZCrayTrace};
+    use crate::{execution::Interpreter, get_last_event, Event, ZCrayTrace};
 
     /// Tests for Comparison operations (without immediate)
     #[test]

--- a/assembly/src/event/context.rs
+++ b/assembly/src/event/context.rs
@@ -5,7 +5,7 @@ use binius_m3::builder::{B16, B32};
 use super::mv::{MVKind, MvihEvent, MvvlEvent, MvvwEvent};
 use crate::{
     execution::{FramePointer, Interpreter, InterpreterError},
-    memory::{AccessSize, MemoryError, Ram, RamValueT, VromValueT},
+    memory::{MemoryError, Ram, RamValueT, VromValueT},
     ValueRom, ZCrayTrace,
 };
 

--- a/assembly/src/event/integer_ops.rs
+++ b/assembly/src/event/integer_ops.rs
@@ -10,7 +10,6 @@ use crate::{
     execution::{FramePointer, InterpreterChannels, InterpreterError},
     fire_non_jump_event,
     gadgets::Add64Gadget,
-    Opcode,
 };
 
 define_bin32_imm_op_event!(
@@ -258,7 +257,6 @@ fn schoolbook_multiplication_intermediate_sums<T: Into<u32>>(
 
 pub trait SignedMulOperation: Debug + Clone {
     fn mul_op(input1: u32, input2: u32) -> u64;
-    fn instruction() -> Opcode;
 }
 
 #[derive(Debug, Clone)]
@@ -270,10 +268,6 @@ impl SignedMulOperation for MulsuOp {
         // the multiplication.
         (input1 as i32 as i64).wrapping_mul(input2 as i64) as u64
     }
-
-    fn instruction() -> Opcode {
-        Opcode::Mulsu
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -284,10 +278,6 @@ impl SignedMulOperation for MulOp {
         // i64 to get the 64-bit value. Otherwise, directly cast as an i64 for
         // the multiplication.
         (input1 as i32 as i64).wrapping_mul(input2 as i32 as i64) as u64
-    }
-
-    fn instruction() -> Opcode {
-        Opcode::Mul
     }
 }
 

--- a/assembly/src/event/mod.rs
+++ b/assembly/src/event/mod.rs
@@ -133,7 +133,6 @@ mod event_helper {
     use binius_m3::builder::B16;
 
     use super::{
-        branch::{BnzEvent, BzEvent},
         context::EventContext,
         integer_ops::{AddEvent, AddiEvent},
         Event,

--- a/assembly/src/event/mv.rs
+++ b/assembly/src/event/mv.rs
@@ -162,8 +162,6 @@ pub struct MvvwEvent {
     pub offset: u16,
 }
 
-// TODO: this is a 4-byte move instruction. So it needs to be updated once we
-// have multi-granularity.
 impl MvvwEvent {
     #[allow(clippy::too_many_arguments)]
     pub const fn new(
@@ -488,8 +486,6 @@ pub struct MvihEvent {
     pub offset: u16,
 }
 
-// TODO: this is a 2-byte move instruction, which sets a 4 byte address to imm
-// zero-extended. So it needs to be updated once we have multi-granularity.
 impl MvihEvent {
     /// This method is called once the next_fp has been set by the CALL
     /// procedure.

--- a/assembly/src/execution/channels.rs
+++ b/assembly/src/execution/channels.rs
@@ -12,7 +12,11 @@ pub struct Channel<T> {
 
 // TODO: Think on unifying types used for recurring variables (fp, pc, ...)
 
+// TODO: Implement flushing rules for emulation debugging for PROM and VROM
+// channels too
+#[allow(unused)]
 pub(crate) type PromChannel = Channel<(u32, u128)>; // PC, opcode, args (so 64 bits overall).
+#[allow(unused)]
 pub(crate) type VromChannel = Channel<u32>;
 pub(crate) type StateChannel = Channel<(B32, u32, u32)>; // pc, *fp, timestamp
 

--- a/assembly/src/execution/emulator.rs
+++ b/assembly/src/execution/emulator.rs
@@ -8,36 +8,17 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use anyhow::ensure;
 use binius_field::{BinaryField, PackedField};
 use binius_m3::builder::{B16, B32};
 use tracing::trace;
 
 use crate::{
     assembler::LabelsFrameSizes,
-    event::{
-        b128::{B128AddEvent, B128MulEvent},
-        b32::{
-            AndEvent, AndiEvent, B32MulEvent, B32MuliEvent, OrEvent, OriEvent, XorEvent, XoriEvent,
-        },
-        branch::{BnzEvent, BzEvent},
-        call::{CalliEvent, CallvEvent, TailiEvent, TailvEvent},
-        comparison::{
-            SleEvent, SleiEvent, SleiuEvent, SleuEvent, SltEvent, SltiEvent, SltiuEvent, SltuEvent,
-        },
-        context::EventContext,
-        integer_ops::{AddEvent, AddiEvent, MulEvent, MuliEvent, MulsuEvent, MuluEvent, SubEvent},
-        jump::{JumpiEvent, JumpvEvent},
-        mv::{LdiEvent, MVInfo, MvihEvent, MvvlEvent, MvvwEvent},
-        ret::RetEvent,
-        shift::*,
-        Event,
-    },
+    context::EventContext,
     execution::{StateChannel, ZCrayTrace},
-    gadgets::Add32Gadget,
-    get_last_event,
     isa::{GenericISA, ISA},
     memory::{Memory, MemoryError},
+    mv::MVInfo,
     opcodes::Opcode,
 };
 

--- a/assembly/src/execution/trace.rs
+++ b/assembly/src/execution/trace.rs
@@ -135,7 +135,7 @@ impl ZCrayTrace {
     ) -> Result<(Self, BoundaryValues), InterpreterError> {
         let mut interpreter = Interpreter::new(isa, frames, pc_field_to_int);
 
-        let mut trace = interpreter.run(memory)?;
+        let trace = interpreter.run(memory)?;
 
         let final_pc = if interpreter.pc == 0 {
             B32::zero()

--- a/assembly/src/isa.rs
+++ b/assembly/src/isa.rs
@@ -12,8 +12,6 @@
 use core::fmt::Debug;
 use std::collections::HashSet;
 
-use binius_m3::builder::ConstraintSystem;
-
 use crate::event::*;
 use crate::Opcode;
 

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -4,10 +4,6 @@
 //! This includes instruction definitions, program parsing and program
 //! execution.
 
-// TODO: Remove these once stable enough
-#![allow(unused)]
-#![allow(dead_code)]
-
 // TODO: Add doc
 
 pub mod assembler;

--- a/assembly/src/memory/mod.rs
+++ b/assembly/src/memory/mod.rs
@@ -120,7 +120,7 @@ impl Memory {
     pub fn ram_mut(&mut self) -> &mut Ram {
         todo!()
     }
-
+    #[cfg(test)]
     /// Returns a reference to the pending VROM updates map.
     pub(crate) const fn vrom_pending_updates(&self) -> &VromPendingUpdates {
         &self.vrom.pending_updates

--- a/assembly/src/memory/vrom.rs
+++ b/assembly/src/memory/vrom.rs
@@ -4,7 +4,7 @@ use binius_m3::builder::{B16, B32};
 use num_traits::Zero;
 
 use super::{AccessSize, MemoryError};
-use crate::{event::context::EventContext, memory::vrom_allocator::VromAllocator, opcodes::Opcode};
+use crate::{memory::vrom_allocator::VromAllocator, opcodes::Opcode};
 
 pub(crate) type VromPendingUpdates = HashMap<u32, Vec<VromUpdate>>;
 
@@ -295,9 +295,9 @@ mod tests {
         assert_eq!(vrom.read::<u32>(2).unwrap(), 0x55667788);
         assert_eq!(vrom.read::<u32>(3).unwrap(), 0x11223344);
 
-        vrom.read::<u32>(3);
-        vrom.read::<u32>(2);
-        vrom.read::<u32>(2);
+        vrom.read::<u32>(3).unwrap();
+        vrom.read::<u32>(2).unwrap();
+        vrom.read::<u32>(2).unwrap();
 
         let vrom_access_counts = vrom.sorted_access_counts();
         assert_eq!(vrom_access_counts.len(), 4);

--- a/assembly/src/opcodes.rs
+++ b/assembly/src/opcodes.rs
@@ -4,7 +4,6 @@ use strum::EnumCount;
 use strum_macros::{Display, EnumCount, IntoStaticStr, VariantArray};
 
 use crate::event::*;
-use crate::{event::context::EventContext, execution::InterpreterError};
 
 /// Represents the set of instructions supported by the zCrayVM.
 #[derive(

--- a/assembly/src/util.rs
+++ b/assembly/src/util.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use binius_m3::builder::B16;
 use tracing_subscriber::EnvFilter;
 
@@ -9,22 +10,13 @@ pub fn init_logger() {
     tracing_subscriber::fmt().with_env_filter(filter).init();
 }
 
+#[cfg(test)]
 #[inline(always)]
 pub(crate) const fn get_binary_slot(i: u16) -> B16 {
     B16::new(i)
 }
 
-/// Helper method to obtain the n-th Fibonacci number.
-pub(crate) fn fibonacci(n: usize) -> u32 {
-    let mut cur_fibs = [0, 1];
-    for _ in 0..n {
-        let s = cur_fibs[0] + cur_fibs[1];
-        cur_fibs[0] = cur_fibs[1];
-        cur_fibs[1] = s;
-    }
-    cur_fibs[0]
-}
-
+#[cfg(test)]
 /// Helper method to obtain the Collatz orbits.
 pub(crate) fn collatz_orbits(initial_val: u32) -> (Vec<u32>, Vec<u32>) {
     let mut cur_value = initial_val;


### PR DESCRIPTION
Just did a pass on assembly, removing
```rust
#![allow(unused)]
#![allow(dead_code)]
```

and outdated TODOs, no actual code change