### PR TITLE
Add "fat" LTO for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ binius_utils = { git = "https://github.com/IrreducibleOSS/binius.git" }
 binius_m3 = { git = "https://github.com/IrreducibleOSS/binius.git" }
 binius_hash = { git = "https://github.com/IrreducibleOSS/binius.git" }
 binius_hal = { git = "https://github.com/IrreducibleOSS/binius.git" }
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
Running the `Fibonacci` example for `n = 100000` in release mode on my Macbook M2 pro:

`no-lto`:
```bash
Trace generation time: 92.275667ms
Proof generation time: 19.911694708s
Proof verification time: 58.984708ms
```

`lto = "fat"`
```bash
Trace generation time: 83.5105ms
Proof generation time: 6.158400292s
Proof verification time: 21.446292ms
```

Compile time is not significantly slower.