### PR TITLE
Make VromAddrSpace a Structured Column

### DIFF
--- a/prover/src/memory.rs
+++ b/prover/src/memory.rs
@@ -4,9 +4,10 @@
 //! to represent the zCrayVM execution in the M3 arithmetization system.
 
 use binius_field::Field;
-use binius_m3::builder::TableWitnessSegment;
 use binius_m3::builder::{Col, ConstraintSystem, TableFiller, TableId, B128, B16, B32};
+use binius_m3::builder::{StructuredDynSize, TableWitnessSegment};
 use binius_m3::gadgets::lookup::LookupProducer;
+use binius_m3::gadgets::structured::fill_incrementing_b32;
 
 use crate::prover::{PROM_MULTIPLICITY_BITS, VROM_MULTIPLICITY_BITS};
 use crate::{
@@ -297,9 +298,10 @@ impl VromAddrSpaceTable {
     /// * `channels` - [`Channels`] IDs for communication with other tables
     pub fn new(cs: &mut ConstraintSystem, channels: &Channels) -> Self {
         let mut table = cs.add_table("vrom_addr_space");
+        table.require_power_of_two_size();
 
         // Add column for address
-        let addr = table.add_committed("addr");
+        let addr = table.add_structured::<B32>("addr", StructuredDynSize::Incrementing);
 
         // Push to VROM address space channel
         table.push(channels.vrom_addr_space_channel, [addr]);
@@ -320,15 +322,10 @@ impl TableFiller<ProverPackedField> for VromAddrSpaceTable {
 
     fn fill<'a>(
         &'a self,
-        rows: impl Iterator<Item = &'a Self::Event>,
+        _rows: impl Iterator<Item = &'a Self::Event>,
         witness: &'a mut TableWitnessSegment<ProverPackedField>,
     ) -> anyhow::Result<()> {
-        let mut addr_col = witness.get_scalars_mut(self.addr)?;
-
-        // Fill the addresses from the provided rows
-        for (i, &addr) in rows.enumerate() {
-            addr_col[i] = B32::new(addr);
-        }
+        fill_incrementing_b32(witness, self.addr)?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR fixes: https://linear.app/irreducible/issue/ZCR-123/m3-add-structured-columns