### PR TITLE
Add issues:write permission to labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           # Allow to remove labels that are no longer relevant when new changes are pushed.
           sync-labels: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the labeler action failing with the [error](https://github.com/PetraProver/PetraVM/actions/runs/14911848171/job/41887926131?pr=150).

