### PR TITLE
Run mdbook CI jobs only when necessary

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,9 +5,15 @@ name: PetraVM mdbook
 on:
   push:
     branches: [main]
+    paths:
+      - 'book/**'
+      - 'README.md'
   pull_request:
     branches:
       - "**"
+    paths:
+      - 'book/**'
+      - 'README.md'
 
 jobs:
   build:


### PR DESCRIPTION
Will be triggered only when `book/` folder or `README.md` (used as main page) will be modified.