### PR TITLE
Bump nightly

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -135,8 +135,7 @@ pub fn get_prom_inst_from_inst_with_label(
         InstructionsWithLabels::Label(s, _) => {
             if labels.get(s).is_none() {
                 return Err(AssemblerError::BadError(format!(
-                    "Label {} not found in the HashMap of labels.",
-                    s
+                    "Label {s} not found in the HashMap of labels."
                 )));
             }
         }

--- a/assembly/src/event/mv.rs
+++ b/assembly/src/event/mv.rs
@@ -139,7 +139,7 @@ impl MVEventOutput {
                 );
                 trace.mvvw.push(new_event);
             }
-            o => panic!("Events for {:?} should already have been generated.", o),
+            o => panic!("Events for {o:?} should already have been generated."),
         }
     }
 }
@@ -945,7 +945,7 @@ mod tests {
         assert_eq!(traces.vrom_pending_updates().len(), pending_updates.len(),);
         for (k, pending_update) in traces.vrom_pending_updates() {
             let expected_update = pending_updates.get(k).unwrap_or_else(|| {
-                panic!("Missing expected update {:?} at addr {}", pending_update, k)
+                panic!("Missing expected update {pending_update:?} at addr {k}")
             });
             assert_eq!(*expected_update, *pending_update,);
         }

--- a/assembly/src/event/shift.rs
+++ b/assembly/src/event/shift.rs
@@ -359,18 +359,15 @@ mod test {
 
             assert_eq!(
                 result_left, expected_left,
-                "LogicalLeft failed for {}: expected 0x{:08x}, got 0x{:08x}",
-                desc, expected_left, result_left
+                "LogicalLeft failed for {desc}: expected 0x{expected_left:08x}, got 0x{result_left:08x}"
             );
             assert_eq!(
                 result_right, expected_right,
-                "LogicalRight failed for {}: expected 0x{:08x}, got 0x{:08x}",
-                desc, expected_right, result_right
+                "LogicalRight failed for {desc}: expected 0x{expected_right:08x}, got 0x{result_right:08x}"
             );
             assert_eq!(
                 result_arith, expected_arith,
-                "ArithmeticRight failed for {}: expected 0x{:08x}, got 0x{:08x}",
-                desc, expected_arith, result_arith
+                "ArithmeticRight failed for {desc}: expected 0x{expected_arith:08x}, got 0x{result_arith:08x}"
             );
         }
     }

--- a/assembly/src/execution/emulator.rs
+++ b/assembly/src/execution/emulator.rs
@@ -223,7 +223,7 @@ impl Interpreter {
                     match error {
                         InterpreterError::Exception(_exc) => {} //TODO: handle exception
                         critical_error => {
-                            panic!("{:?}", critical_error);
+                            panic!("{critical_error:?}");
                         } //TODO: properly format error
                     }
                 }

--- a/assembly/src/memory/vrom_allocator.rs
+++ b/assembly/src/memory/vrom_allocator.rs
@@ -286,9 +286,7 @@ mod tests {
             assert_eq!(
                 addr % padded,
                 0,
-                "Address {} is not aligned to {}",
-                addr,
-                padded
+                "Address {addr} is not aligned to {padded}"
             );
         }
 
@@ -300,10 +298,7 @@ mod tests {
             let (addr2, _) = window[1];
             assert!(
                 addr1 + requested <= addr2,
-                "Allocation {}+{} overlaps with {}",
-                addr1,
-                requested,
-                addr2
+                "Allocation {addr1}+{requested} overlaps with {addr2}"
             );
         }
 

--- a/assembly/src/parser/instructions_with_labels.rs
+++ b/assembly/src/parser/instructions_with_labels.rs
@@ -216,9 +216,9 @@ impl std::fmt::Display for InstructionsWithLabels {
         match self {
             InstructionsWithLabels::Label(label, frame_size) => {
                 if let Some(size) = frame_size {
-                    write!(f, "#[framesize(0x{:x})]\n{}:", size, label)
+                    write!(f, "#[framesize(0x{size:x})]\n{label}:")
                 } else {
-                    write!(f, "{}:", label)
+                    write!(f, "{label}:")
                 }
             }
             InstructionsWithLabels::B32Mul { dst, src1, src2 } => {

--- a/assembly/src/parser/tests.rs
+++ b/assembly/src/parser/tests.rs
@@ -15,7 +15,7 @@ mod test_parser {
 
     fn ensure_parser_succeeds(rule: Rule, asm: &str) {
         let parser = AsmParser::parse(rule, asm);
-        assert!(parser.is_ok(), "assembly failed to parse: {}", asm);
+        assert!(parser.is_ok(), "assembly failed to parse: {asm}");
     }
 
     fn ensure_parser_fails(rule: Rule, asm: &str) {
@@ -285,8 +285,7 @@ mod test_parser {
             let expected_inst = &expected_prom[i];
             assert_eq!(
                 *inst, *expected_inst,
-                "Value for index {:?} in PROM is {:?} but is {:?} in expected PROM",
-                i, inst, expected_inst
+                "Value for index {i:?} in PROM is {inst:?} but is {expected_inst:?} in expected PROM"
             );
         }
     }

--- a/assembly/tests/bezout.rs
+++ b/assembly/tests/bezout.rs
@@ -30,10 +30,7 @@ fn test_bezout_integration() {
         assert_eq!(
             bezout_frame.get_vrom_expected::<u32>(4),
             expected_gcd,
-            "GCD of {} and {} should be {}",
-            a,
-            b,
-            expected_gcd
+            "GCD of {a} and {b} should be {expected_gcd}"
         );
 
         // TODO: Replace `u32` with `i32` once `VromValueT` is implemented for `i32`...
@@ -44,9 +41,7 @@ fn test_bezout_integration() {
         assert_eq!(
             a as i32 * x + b as i32 * y,
             expected_gcd as i32,
-            "Bezout coefficients do not satisfy the equation for a = {}, b = {}",
-            a,
-            b
+            "Bezout coefficients do not satisfy the equation for a = {a}, b = {b}"
         );
     }
 }

--- a/assembly/tests/branch.rs
+++ b/assembly/tests/branch.rs
@@ -11,8 +11,7 @@ fn run_test(input: u32, expected: u32, condition: &str) {
     assert_eq!(
         branch_frame.get_vrom_expected::<u32>(3),
         expected,
-        "Condition: {}",
-        condition
+        "Condition: {condition}"
     );
 }
 

--- a/assembly/tests/collatz.rs
+++ b/assembly/tests/collatz.rs
@@ -19,8 +19,7 @@ fn test_collatz_integration() {
         assert_eq!(
             collatz_frame.get_vrom_expected::<u32>(3),
             1,
-            "Final result should be 1 for initial value {}",
-            initial_value
+            "Final result should be 1 for initial value {initial_value}"
         );
     }
 }

--- a/assembly/tests/common/test_utils.rs
+++ b/assembly/tests/common/test_utils.rs
@@ -148,8 +148,7 @@ impl AllocatedFrame {
 
     fn vrom_read_err_panic(read_size_str: &str) -> ! {
         panic!(
-            "Reading a {} from VROM memory that is expected to be filled",
-            read_size_str
+            "Reading a {read_size_str} from VROM memory that is expected to be filled"
         )
     }
 }

--- a/assembly/tests/common/test_utils.rs
+++ b/assembly/tests/common/test_utils.rs
@@ -147,9 +147,7 @@ impl AllocatedFrame {
     }
 
     fn vrom_read_err_panic(read_size_str: &str) -> ! {
-        panic!(
-            "Reading a {read_size_str} from VROM memory that is expected to be filled"
-        )
+        panic!("Reading a {read_size_str} from VROM memory that is expected to be filled")
     }
 }
 

--- a/assembly/tests/div.rs
+++ b/assembly/tests/div.rs
@@ -12,16 +12,12 @@ fn run_test(a: u32, b: u32, expected_q: u32, expected_r: u32) {
     assert_eq!(
         div_frame.get_vrom_expected::<u32>(4),
         expected_q,
-        "Quotient for div({}, {})",
-        a,
-        b
+        "Quotient for div({a}, {b})"
     );
     assert_eq!(
         div_frame.get_vrom_expected::<u32>(5),
         expected_r,
-        "Remainder for div({}, {})",
-        a,
-        b
+        "Remainder for div({a}, {b})"
     );
 }
 

--- a/assembly/tests/fibonacci.rs
+++ b/assembly/tests/fibonacci.rs
@@ -33,24 +33,21 @@ fn test_fibonacci_integration() {
         assert_eq!(
             fib_helper_frame.get_vrom_expected::<u32>(2),
             cur_fibs[0],
-            "Incorrect 'a' value at iteration {}",
-            i
+            "Incorrect 'a' value at iteration {i}"
         );
 
         // Check current b value
         assert_eq!(
             fib_helper_frame.get_vrom_expected::<u32>(3),
             cur_fibs[1],
-            "Incorrect 'b' value at iteration {}",
-            i
+            "Incorrect 'b' value at iteration {i}"
         );
 
         // Check a + b value
         assert_eq!(
             fib_helper_frame.get_vrom_expected::<u32>(7),
             s,
-            "Incorrect 'a + b' value at iteration {}",
-            i
+            "Incorrect 'a + b' value at iteration {i}"
         );
 
         // Update fibonacci values for next iteration

--- a/assembly/tests/opcodes.rs
+++ b/assembly/tests/opcodes.rs
@@ -21,8 +21,7 @@ fn test_opcodes() {
 
     assert!(
         unseen_types_remaining.is_empty(),
-        "Some existing opcodes were not present in the opcode test program: {:#?}",
-        unseen_types_remaining
+        "Some existing opcodes were not present in the opcode test program: {unseen_types_remaining:#?}"
     );
 
     // Verify the final result is 0

--- a/assembly/tests/tail_long_div.rs
+++ b/assembly/tests/tail_long_div.rs
@@ -12,18 +12,14 @@ fn run_test(dividend: u32, divisor: u32, expected_quotient: u32, expected_remain
     assert_eq!(
         tail_long_div_frame.get_vrom_expected::<u32>(4),
         expected_quotient,
-        "Quotient mismatch for dividend = {}, divisor = {}",
-        dividend,
-        divisor
+        "Quotient mismatch for dividend = {dividend}, divisor = {divisor}"
     );
 
     // Verify the remainder
     assert_eq!(
         tail_long_div_frame.get_vrom_expected::<u32>(5),
         expected_remainder,
-        "Remainder mismatch for dividend = {}, divisor = {}",
-        dividend,
-        divisor
+        "Remainder mismatch for dividend = {dividend}, divisor = {divisor}"
     );
 }
 

--- a/prover/src/opcodes/binary/b128.rs
+++ b/prover/src/opcodes/binary/b128.rs
@@ -2,7 +2,6 @@
 //!
 //! This module contains tables for binary field arithmetic operations.
 
-use std::any::Any;
 
 use binius_field::underlier::Divisible;
 use binius_m3::builder::{
@@ -208,10 +207,6 @@ impl Table for B128AddTable {
             dst_abs_addr,
         }
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl_b128_table_filler!(B128AddTable, B128AddEvent);
@@ -332,10 +327,6 @@ impl Table for B128MulTable {
             src2_abs_addr,
             dst_abs_addr,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/binary/b128.rs
+++ b/prover/src/opcodes/binary/b128.rs
@@ -2,7 +2,6 @@
 //!
 //! This module contains tables for binary field arithmetic operations.
 
-
 use binius_field::underlier::Divisible;
 use binius_m3::builder::{
     upcast_expr, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B128, B32,

--- a/prover/src/opcodes/binary/b32.rs
+++ b/prover/src/opcodes/binary/b32.rs
@@ -2,7 +2,6 @@
 //!
 //! This module contains tables for binary field arithmetic operations.
 
-use std::any::Any;
 
 use binius_field::Field;
 use binius_m3::builder::{
@@ -158,10 +157,6 @@ impl Table for B32MulTable {
             dst_abs_addr,
         }
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl_b32_table_filler!(B32MulTable, B32MulEvent);
@@ -229,10 +224,6 @@ impl Table for XorTable {
             dst_abs_addr,
             dst_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -306,10 +297,6 @@ impl Table for AndTable {
             dst_abs_addr,
             dst_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -386,10 +373,6 @@ impl Table for OrTable {
             dst_abs_addr,
             dst_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -477,10 +460,6 @@ impl Table for OriTable {
             dst_val,
             dst_val_unpacked,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -571,10 +550,6 @@ impl Table for XoriTable {
             src_abs,
             src_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -670,10 +645,6 @@ impl Table for AndiTable {
             src_val_unpacked,
             src_val_low,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -819,10 +790,6 @@ impl Table for B32MuliTable {
             second_instruction_pc,
             imm_high,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/binary/b32.rs
+++ b/prover/src/opcodes/binary/b32.rs
@@ -2,7 +2,6 @@
 //!
 //! This module contains tables for binary field arithmetic operations.
 
-
 use binius_field::Field;
 use binius_m3::builder::{
     upcast_col, upcast_expr, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B1,

--- a/prover/src/opcodes/branch.rs
+++ b/prover/src/opcodes/branch.rs
@@ -1,5 +1,3 @@
-
-
 use binius_field::Field;
 use binius_m3::builder::{
     upcast_col, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32,

--- a/prover/src/opcodes/branch.rs
+++ b/prover/src/opcodes/branch.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+
 
 use binius_field::Field;
 use binius_m3::builder::{
@@ -53,10 +53,6 @@ impl Table for BnzTable {
             cond_abs,
             cond_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -129,10 +125,6 @@ impl Table for BzTable {
             state_cols,
             cond_abs,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/call.rs
+++ b/prover/src/opcodes/call.rs
@@ -1,6 +1,5 @@
 //! Function call instructions for the PetraVM M3 circuit.
 
-use std::any::Any;
 
 use binius_m3::builder::{
     upcast_col, upcast_expr, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32,
@@ -96,10 +95,6 @@ impl Table for TailiTable {
             fp_plus_1,
             next_fp_plus_1,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -244,10 +239,6 @@ impl Table for TailvTable {
             next_fp_plus_1,
         }
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl TableFiller<ProverPackedField> for TailvTable {
@@ -378,10 +369,6 @@ impl Table for CalliTable {
             next_pc_val,
             next_fp_slot_1,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -515,10 +502,6 @@ impl Table for CallvTable {
             next_pc_val,
             next_fp_slot_1,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/call.rs
+++ b/prover/src/opcodes/call.rs
@@ -1,6 +1,5 @@
 //! Function call instructions for the PetraVM M3 circuit.
 
-
 use binius_m3::builder::{
     upcast_col, upcast_expr, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32,
 };

--- a/prover/src/opcodes/call.rs
+++ b/prover/src/opcodes/call.rs
@@ -573,7 +573,7 @@ mod tests {
         let asm_code = format!(
             "#[framesize(0x10)]\n\
             _start:\n\
-                LDI.W @3, #{}\n\
+                LDI.W @3, #{pc_val}\n\
                 MVV.W @4[2], @2\n\
                 MVI.H @4[3], #2\n\
                 TAILV @3, @4\n\
@@ -586,8 +586,7 @@ mod tests {
                 LDI.W @4, #0\n\
                 MVV.W @5[2], @2\n\
                 MVV.W @5[3], @4\n\
-                TAILI loop, @5\n",
-            pc_val
+                TAILI loop, @5\n"
         );
 
         generate_trace(asm_code, None, None)
@@ -601,7 +600,7 @@ mod tests {
         let asm_code = format!(
             "#[framesize(0x10)]\n\
             _start:\n\
-                LDI.W @3, #{}\n\
+                LDI.W @3, #{pc_val}\n\
                 MVV.W @4[2], @2\n\
                 MVI.H @4[3], #2\n\
                 CALLV @3, @4\n\
@@ -616,8 +615,7 @@ mod tests {
                 MVV.W @5[2], @2\n\
                 MVV.W @5[3], @4\n\
                 CALLI loop, @5\n\
-                RET\n",
-            pc_val
+                RET\n"
         );
 
         generate_trace(asm_code, None, None)

--- a/prover/src/opcodes/comparison.rs
+++ b/prover/src/opcodes/comparison.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use binius_field::PackedField;
 use binius_m3::{
     builder::{
@@ -104,10 +102,6 @@ impl Table for SltuTable {
             src2_val,
             subber,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -231,10 +225,6 @@ impl Table for SltiuTable {
             imm_32b,
             subber,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -367,10 +357,6 @@ impl Table for SleuTable {
             subber,
         }
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl TableFiller<ProverPackedField> for SleuTable {
@@ -502,10 +488,6 @@ impl Table for SleiuTable {
             imm_32b,
             subber,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/integer_ops.rs
+++ b/prover/src/opcodes/integer_ops.rs
@@ -772,7 +772,7 @@ impl Table for MuliTable {
 
         // Unpack src_val_unpacked to [Col<B1>; 32] for MulSS32::with_input
         let src_val_unpacked_bits: [Col<B1>; 32] = std::array::from_fn(|i| {
-            table.add_selected(format!("src_val_unpacked_bit_{}", i), src_val_unpacked, i)
+            table.add_selected(format!("src_val_unpacked_bit_{i}"), src_val_unpacked, i)
         });
 
         let SignExtendedImmediateOutput {
@@ -786,7 +786,7 @@ impl Table for MuliTable {
         // Unpack signed_imm_unpacked to [Col<B1>; 32] for MulSS32::with_input
         let signed_imm_unpacked_bits: [Col<B1>; 32] = std::array::from_fn(|i| {
             table.add_selected(
-                format!("signed_imm_unpacked_bit_{}", i),
+                format!("signed_imm_unpacked_bit_{i}"),
                 signed_imm_unpacked,
                 i,
             )
@@ -920,11 +920,10 @@ mod tests {
         let asm_code = format!(
             "#[framesize(0x10)]\n\
              _start: 
-                LDI.W @2, #{}\n\
-                ADDI @3, @2, #{}\n\
-                MULI @4, @2, #{}\n\
-                RET\n",
-            src_value, imm_value, imm_value
+                LDI.W @2, #{src_value}\n\
+                ADDI @3, @2, #{imm_value}\n\
+                MULI @4, @2, #{imm_value}\n\
+                RET\n"
         );
 
         let addi_result = src_value.wrapping_add((imm_value as i16 as i32) as u32);
@@ -953,13 +952,12 @@ mod tests {
         let asm_code = format!(
             "#[framesize(0x10)]\n\
              _start: 
-                LDI.W @2, #{}\n\
-                LDI.W @3, #{}\n\
+                LDI.W @2, #{src1_value}\n\
+                LDI.W @3, #{src2_value}\n\
                 SUB @4, @2, @3\n\
                 ADD @5, @2, @3\n\
                 MULU @6, @2, @3\n\
-                RET\n",
-            src1_value, src2_value
+                RET\n"
         );
 
         let mulu_result = src1_value as u64 * src2_value as u64;

--- a/prover/src/opcodes/integer_ops.rs
+++ b/prover/src/opcodes/integer_ops.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use binius_field::{Field, PackedBinaryField32x1b};
 use binius_m3::{
     builder::{
@@ -148,10 +146,6 @@ impl Table for AddTable {
             add_op,
         }
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl TableFiller<ProverPackedField> for AddTable {
@@ -270,10 +264,6 @@ impl Table for SubTable {
             add_op,
             dst_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -405,10 +395,6 @@ impl Table for AddiTable {
             ones,
             add_op,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -545,10 +531,6 @@ impl Table for MuluTable {
             mul_op,
         }
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl TableFiller<ProverPackedField> for MuluTable {
@@ -683,10 +665,6 @@ impl Table for MulTable {
             src2_val,
             mul_op,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -845,10 +823,6 @@ impl Table for MuliTable {
             ones,
             mul_op,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/jump.rs
+++ b/prover/src/opcodes/jump.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+
 
 use binius_m3::builder::{
     upcast_col, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32,
@@ -41,10 +41,6 @@ impl Table for JumpiTable {
             id: table.id(),
             state_cols,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -118,10 +114,6 @@ impl Table for JumpvTable {
             offset_addr,
             target_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/jump.rs
+++ b/prover/src/opcodes/jump.rs
@@ -1,5 +1,3 @@
-
-
 use binius_m3::builder::{
     upcast_col, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32,
 };

--- a/prover/src/opcodes/jump.rs
+++ b/prover/src/opcodes/jump.rs
@@ -170,7 +170,7 @@ mod tests {
         let asm_code = format!(
             "#[framesize(0x10)]\n\
         _start:\n\
-            LDI.W @3, #{}\n\
+            LDI.W @3, #{pc_val}\n\
             J @3\n\
             ;; Code that should be skipped\n\
             LDI.W @2, #998\n\
@@ -181,7 +181,6 @@ mod tests {
         jump_target:\n\
             LDI.W @2, #0  ;; Success\n\
             RET\n",
-            pc_val,
         );
 
         // Add VROM writes with appropriate access counts

--- a/prover/src/opcodes/ldi.rs
+++ b/prover/src/opcodes/ldi.rs
@@ -3,7 +3,6 @@
 //! This module contains the LDI table which handles loading immediate values
 //! into VROM locations in the PetraVM execution.
 
-use std::any::Any;
 
 use binius_m3::builder::{
     upcast_col, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32,
@@ -74,10 +73,6 @@ impl Table for LdiTable {
             vrom_abs_addr,
             imm,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/ldi.rs
+++ b/prover/src/opcodes/ldi.rs
@@ -3,7 +3,6 @@
 //! This module contains the LDI table which handles loading immediate values
 //! into VROM locations in the PetraVM execution.
 
-
 use binius_m3::builder::{
     upcast_col, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32,
 };

--- a/prover/src/opcodes/mv.rs
+++ b/prover/src/opcodes/mv.rs
@@ -1,7 +1,5 @@
 //! Move Value tables implementation for the PetraVM M3 circuit.
 
-use std::any::Any;
-
 use binius_field::underlier::Divisible;
 use binius_m3::builder::B128;
 use binius_m3::builder::{
@@ -99,10 +97,6 @@ impl Table for MvvwTable {
             dst_addr,
             src_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -221,10 +215,6 @@ impl Table for MvihTable {
             final_dst_addr,
             imm_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 
@@ -367,10 +357,6 @@ impl Table for MvvlTable {
             dst_lookup,
             src_val,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/ret.rs
+++ b/prover/src/opcodes/ret.rs
@@ -3,7 +3,6 @@
 //! This module contains the RET table which handles return operations
 //! in the PetraVM execution.
 
-
 use binius_field::Field;
 use binius_m3::builder::{Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32};
 use petravm_asm::{opcodes::Opcode, RetEvent};

--- a/prover/src/opcodes/ret.rs
+++ b/prover/src/opcodes/ret.rs
@@ -3,7 +3,6 @@
 //! This module contains the RET table which handles return operations
 //! in the PetraVM execution.
 
-use std::any::Any;
 
 use binius_field::Field;
 use binius_m3::builder::{Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, B32};
@@ -72,10 +71,6 @@ impl Table for RetTable {
             next_pc,
             next_fp,
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/prover/src/opcodes/shift.rs
+++ b/prover/src/opcodes/shift.rs
@@ -724,15 +724,14 @@ mod tests {
         let asm_code = format!(
             "#[framesize(0x10)]\n\
             _start:\n\
-            LDI.W @3, #{}\n\
-            SRLI @4, @2, #{}\n\
+            LDI.W @3, #{shift_amount}\n\
+            SRLI @4, @2, #{imm}\n\
             SRL  @5, @2, @3 \n\
-            SLLI @6, @2, #{}\n\
+            SLLI @6, @2, #{imm}\n\
             SLL  @7, @2, @3 \n\
-            SRAI @8, @2, #{}\n\
+            SRAI @8, @2, #{imm}\n\
             SRA  @9, @2, @3 \n\
-            RET\n",
-            shift_amount, imm, imm, imm
+            RET\n"
         );
 
         let init_values = vec![0, 0, val];

--- a/prover/src/opcodes/shift.rs
+++ b/prover/src/opcodes/shift.rs
@@ -92,10 +92,6 @@ macro_rules! define_logic_shift_table {
                     src_val,
                 }
             }
-
-            fn as_any(&self) -> &dyn std::any::Any {
-                self
-            }
         }
 
         impl TableFiller<ProverPackedField> for $Name {
@@ -225,10 +221,6 @@ macro_rules! define_logic_shift_table {
                     shift_vrom_val,
                     shift_vrom_val_high,
                 }
-            }
-
-            fn as_any(&self) -> &dyn std::any::Any {
-                self
             }
         }
 
@@ -425,10 +417,6 @@ impl Table for SraTable {
             inverted_output,
             result,
         }
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 
@@ -630,10 +618,6 @@ impl Table for SraiTable {
             inverted_output,
             result,
         }
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 

--- a/prover/src/table.rs
+++ b/prover/src/table.rs
@@ -6,8 +6,6 @@
 //! [`ISA`](petravm_asm::isa::ISA) interface, and are dynamically managed
 //! when building the proving circuit.
 
-use std::any::Any;
-
 use anyhow::anyhow;
 use binius_m3::builder::ConstraintSystem;
 use binius_m3::builder::TableFiller;
@@ -33,7 +31,7 @@ pub trait TableInfo: InstructionInfo {
 ///
 /// The associated `Event` type defines the kind of event this table
 /// expects during witness generation.
-pub trait Table: Any {
+pub trait Table {
     /// The event type associated with this table.
     type Event: 'static;
 
@@ -49,10 +47,6 @@ pub trait Table: Any {
     fn new(cs: &mut ConstraintSystem, channels: &Channels) -> Self
     where
         Self: Sized;
-
-    /// Helper method to downcast a [`Table`] into a concrete instruction
-    /// instance.
-    fn as_any(&self) -> &dyn Any;
 }
 
 /// Trait use for convenience to easily fill a witness from a provided

--- a/prover/src/test_utils.rs
+++ b/prover/src/test_utils.rs
@@ -102,7 +102,7 @@ pub fn generate_trace(
 ) -> Result<Trace> {
     // Compile the assembly code
     let compiled_program = Assembler::from_code(&asm_code)?;
-    trace!("compiled program = {:?}", compiled_program);
+    trace!("compiled program = {compiled_program:?}");
 
     // Keep a copy of the program for later
     let mut program = compiled_program.prom.clone();

--- a/prover/tests/simple.rs
+++ b/prover/tests/simple.rs
@@ -153,16 +153,15 @@ fn generate_integer_ops_trace(src1_value: u32, src2_value: u32) -> Result<Trace>
     let asm_code = format!(
         "#[framesize(0x10)]\n\
          _start: 
-            LDI.W @2, #{}\n\
-            LDI.W @3, #{}\n\
+            LDI.W @2, #{src1_value}\n\
+            LDI.W @3, #{src2_value}\n\
             ;; Skip @4 to test a gap in vrom writes
             ADD @5, @2, @3\n\
-            ADDI @6, @2, #{}\n\
+            ADDI @6, @2, #{imm}\n\
             MULU @8, @2, @3\n\
             MUL @10, @2, @3\n\
-            MULI @12, @2, #{}\n\
-            RET\n",
-        src1_value, src2_value, imm, imm
+            MULI @12, @2, #{imm}\n\
+            RET\n"
     );
 
     generate_trace(asm_code, None, None)
@@ -342,18 +341,17 @@ fn generate_all_binary_ops_trace() -> Result<Trace> {
     let asm_code = format!(
         "#[framesize(0x10)]\n\
         _start: 
-            LDI.W @2, #{}\n\
-            LDI.W @3, #{}\n\
+            LDI.W @2, #{val1}\n\
+            LDI.W @3, #{val2}\n\
             AND @4, @2, @3\n\
             OR @5, @2, @3\n\
             XOR @6, @2, @3\n\
-            ANDI @7, @2, #{}\n\
-            ORI @8, @2, #{}\n\
-            XORI @9, @2, #{}\n\
+            ANDI @7, @2, #{imm}\n\
+            ORI @8, @2, #{imm}\n\
+            XORI @9, @2, #{imm}\n\
             B32_MUL @10, @2, @3\n\
-            B32_MULI @11, @2, #{}\n\
-            RET\n",
-        val1, val2, imm, imm, imm, imm32
+            B32_MULI @11, @2, #{imm32}\n\
+            RET\n"
     );
 
     // Calculate expected results

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-12-01"
+channel = "nightly-2025-05-10"


### PR DESCRIPTION
Toolchain hadn't been updated since the start (`binius`' one has). Figured we could as well set it to latest to be fine for a while (if we want to keep a pinned one for reproducibility and consistency).

Allows to simplify the `Table` trait by removing the explicit upcasting method as pointed out by Sergei on slack.

Also seems `clippy:uninlined_format_args` lint moved to warnings now.