### PR TITLE
Speed-up program emulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["zkvm", "zero-knowledge", "binius", "rust", "snark"]
 categories = ["cryptography", "compilers", "wasm"]
 
 [workspace.dependencies]
+ahash = "0.8.12"
 anyhow = "1.0"
 tracing = "0.1.41"
 tracing-forest = { version = "0.1.6", features = ["ansi"] }

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -13,6 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+ahash.workspace = true
 anyhow.workspace = true
 binius_field.workspace = true
 binius_utils.workspace = true

--- a/assembly/src/execution/emulator.rs
+++ b/assembly/src/execution/emulator.rs
@@ -252,6 +252,7 @@ impl Interpreter {
         debug_assert_eq!(field_pc, G.pow(self.pc as u64 - 1));
 
         let opcode = Opcode::try_from(opcode.val()).map_err(|_| InterpreterError::InvalidOpcode)?;
+        #[cfg(debug_assertions)]
         if !self.isa.is_supported(opcode) {
             return Err(InterpreterError::UnsupportedOpcode(opcode));
         }

--- a/assembly/src/execution/trace.rs
+++ b/assembly/src/execution/trace.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 
+use ahash::AHashMap;
 use binius_field::{Field, PackedField};
 use binius_m3::builder::B32;
 
@@ -84,7 +85,7 @@ pub struct PetraTrace {
     memory: Memory,
     /// A map of an instruction's field PC to the number of times that
     /// instruction has been executed.
-    pub instruction_counter: HashMap<B32, u32>,
+    pub instruction_counter: AHashMap<B32, u32>,
 }
 
 pub struct BoundaryValues {

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -13,6 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+ahash.workspace = true
 anyhow.workspace = true
 bumpalo = { version = "3.17.0", features = ["collections"] }
 bytemuck = { version = "1.23.0", features = ["derive", "min_const_generics"] }

--- a/prover/src/model.rs
+++ b/prover/src/model.rs
@@ -3,8 +3,7 @@
 //! This module contains the data structures used to represent execution traces
 //! and events needed for the proving system.
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use anyhow::Result;
 use binius_m3::builder::B32;
 use paste::paste;
@@ -164,7 +163,7 @@ impl Trace {
     ///
     /// # Arguments
     /// * `instructions` - An iterator of InterpreterInstructions to add
-    pub fn add_instructions<I>(&mut self, instructions: I, instruction_counter: &HashMap<B32, u32>)
+    pub fn add_instructions<I>(&mut self, instructions: I, instruction_counter: &AHashMap<B32, u32>)
     where
         I: IntoIterator<Item = InterpreterInstruction>,
     {

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -66,7 +66,7 @@ impl Prover {
 
         // 4. Fill VROM skip table with skipped addresses
         // Generate the list of skipped addresses (addresses not in vrom_writes)
-        let write_addrs: std::collections::HashSet<u32> =
+        let write_addrs: ahash::AHashSet<u32> =
             trace.vrom_writes.iter().map(|(addr, _, _)| *addr).collect();
 
         let vrom_skips: Vec<u32> = (0..vrom_addr_space_size as u32)


### PR DESCRIPTION
Two fairly light tweaks that end up speeding-up program emulation by ~23% on my M2 pro when running the Fibonacci example with `-n 10_000_000`.

- only ensuring opcode support (as per defined ISA) with `debug_assertions` enabled, as this check isn't necessary per say in `release`, and would break the prover in case of unsupported opcode inserted
   - removes about 8% 
- using `ahash` faster hasher (embedded into `ahash::AHashMap`) instead of the default SipHash for the `instruction_counter` map
   - removes an additional 15%

Avg on `main`: 7.30 sec
Avg on this branch: 5.45sec