### PR TITLE
docs: removed redundant "## Dependencies"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,6 @@ We use plenty of useful crates from the Rust ecosystem. When including a crate a
   to find an alternative.
 * Is it developed by one person or an organization?
 
-We use plenty of useful crates from the Rust ecosystem. When including a crate as a dependency, be sure to assess:
-
-* Is it widely used? You can see when it was published and total downloads on `crates.io`.
-* Is it maintained? If the documentation has an explicit deprecation notice or has not been updated in a long time, try
-  to find an alternative.
-* Is it developed by one person or an organization?
-
 ## First-time contributions
 
 The project welcomes first time contributions from developers who want to learn more about PetraVM and make an impact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We use plenty of useful crates from the Rust ecosystem. When including a crate a
 * Is it widely used? You can see when it was published and total downloads on `crates.io`.
 * Is it maintained? If the documentation has an explicit deprecation notice or has not been updated in a long time, try
   to find an alternative.
-* Is it developed by one person or an organization?## Dependencies
+* Is it developed by one person or an organization?
 
 We use plenty of useful crates from the Rust ecosystem. When including a crate as a dependency, be sure to assess:
 


### PR DESCRIPTION
<img width="942" alt="Снимок экрана 2025-05-16 в 20 27 46" src="https://github.com/user-attachments/assets/e2e41106-efc8-40f9-ada3-3aedec66f0e7" />
Spotted an empty "## Dependencies" section hanging around - figured it wasn’t doing much, so I got rid of it.