### PR TITLE
tracing-profile integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Cargo.lock
 # already existing elements were commented out
 
 #/target
+
+/*.perfetto-trace
+.last_perfetto_trace_path

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = "1.0"
 tracing = "0.1.41"
 tracing-forest = { version = "0.1.6", features = ["ansi"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-profile = "0.10.6"
 
 # Binius dependencies
 binius_core = { git = "https://github.com/IrreducibleOSS/binius.git" }

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -28,9 +28,14 @@ thiserror = "2.0.12"
 tracing.workspace = true
 tracing-forest.workspace = true
 tracing-subscriber.workspace = true
+tracing-profile.workspace = true
 
 # Binius dependencies
 binius_m3.workspace = true
 
 [dev-dependencies]
 rand = "0.9.1"
+
+[features]
+tracing-profile = []
+perfetto = ["tracing-profile/perfetto"]

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -27,8 +27,8 @@ strum_macros = "0.27.1"
 thiserror = "2.0.12"
 tracing.workspace = true
 tracing-forest.workspace = true
-tracing-subscriber.workspace = true
 tracing-profile.workspace = true
+tracing-subscriber.workspace = true
 
 # Binius dependencies
 binius_m3.workspace = true

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -38,4 +38,4 @@ rand = "0.9.1"
 
 [features]
 tracing-profile = []
-perfetto = ["tracing-profile/perfetto"]
+perfetto = ["tracing-profile", "tracing-profile/perfetto"]

--- a/assembly/src/util.rs
+++ b/assembly/src/util.rs
@@ -1,14 +1,19 @@
+use binius_utils::rayon::adjust_thread_pool;
 use tracing_forest::ForestLayer;
+use tracing_profile::init_tracing;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
-
 /// Initializes the global tracing subscriber.
 ///
 /// The default `Level` is `INFO`. It can be overridden with `RUSTFLAGS`.
-pub fn init_logger() {
-    if cfg!(feature = "tracing-profile") || cfg!(feature = "perfetto") {
-        use tracing_profile::init_tracing;
-        let _guard = init_tracing().expect("failed to initialize tracing");
+pub fn init_logger() -> Option<impl Drop> {
+    if cfg!(feature = "tracing-profile") {
+        adjust_thread_pool()
+            .as_ref()
+            .expect("failed to init thread pool");
+
+        let guard = init_tracing().expect("failed to initialize tracing");
+        return Some(guard);
     } else {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
@@ -17,4 +22,5 @@ pub fn init_logger() {
             .with(ForestLayer::default())
             .init();
     }
+    None
 }

--- a/assembly/src/util.rs
+++ b/assembly/src/util.rs
@@ -6,10 +6,15 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 ///
 /// The default `Level` is `INFO`. It can be overridden with `RUSTFLAGS`.
 pub fn init_logger() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    if cfg!(feature = "tracing-profile") || cfg!(feature = "perfetto") {
+        use tracing_profile::init_tracing;
+        let _guard = init_tracing().expect("failed to initialize tracing");
+    } else {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(ForestLayer::default())
-        .init();
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(ForestLayer::default())
+            .init();
+    }
 }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "2.0.12"
 tracing.workspace = true
 tracing-forest.workspace = true
 tracing-subscriber.workspace = true
+tracing-profile.workspace = true
 
 # Binius dependencies
 binius_core.workspace = true

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -24,8 +24,8 @@ petravm-asm = { path = "../assembly" }
 thiserror = "2.0.12"
 tracing.workspace = true
 tracing-forest.workspace = true
-tracing-subscriber.workspace = true
 tracing-profile.workspace = true
+tracing-subscriber.workspace = true
 
 # Binius dependencies
 binius_core.workspace = true

--- a/prover/examples/collatz.rs
+++ b/prover/examples/collatz.rs
@@ -15,7 +15,7 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    petravm_asm::init_logger();
+    let _guard = petravm_asm::init_logger();
 
     let num_steps = collatz(args.n);
 

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -46,6 +46,7 @@ impl Prover {
         allocator: &'a Bump,
     ) -> Result<WitnessIndex<'_, 'a, ProverPackedField>> {
         // Build the witness structure
+        #[allow(deprecated)]
         let mut witness = self
             .circuit
             .cs


### PR DESCRIPTION
This allows generating [Perfetto](https://ui.perfetto.dev/) traces, just like in Binius.

You can run it with:
```bash
cargo run --example collatz --release --features "perfetto"
```

Unfortunately, it only works on Linux machines.