### PR TITLE
Use WitnessIndex::new directly

### DIFF
--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -46,10 +46,7 @@ impl Prover {
         allocator: &'a Bump,
     ) -> Result<WitnessIndex<'_, 'a, ProverPackedField>> {
         // Build the witness structure
-        let mut witness = self
-            .circuit
-            .cs
-            .build_witness::<ProverPackedField>(allocator);
+        let mut witness = WitnessIndex::new(&self.circuit.cs, allocator);
 
         // Fill all table witnesses in sequence
 


### PR DESCRIPTION
This squashes a deprecation warning. Note `build_witness` was already deprecated for some time, it was just not annotated with `#[deprecated]`, but now it is.