### PR TITLE
Deterministic assembly parsing support

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -140,7 +140,9 @@ pub fn get_prom_inst_from_inst_with_label(
                 )));
             }
         }
-        InstructionsWithLabels::B32Mul { dst, src1, src2 } => {
+        InstructionsWithLabels::B32Mul {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::B32Mul.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -152,7 +154,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::B32Muli { dst, src1, imm } => {
+        InstructionsWithLabels::B32Muli { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::B32Muli.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -174,7 +176,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::B128Add { dst, src1, src2 } => {
+        InstructionsWithLabels::B128Add {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::B128Add.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -186,7 +190,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::B128Mul { dst, src1, src2 } => {
+        InstructionsWithLabels::B128Mul {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::B128Mul.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -198,7 +204,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Mvih { dst, imm } => {
+        InstructionsWithLabels::Mvih { dst, imm, .. } => {
             let instruction = [
                 Opcode::Mvih.get_field_elt(),
                 dst.get_slot_16bfield_val(),
@@ -209,7 +215,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Mvvw { dst, src } => {
+        InstructionsWithLabels::Mvvw { dst, src, .. } => {
             let instruction = [
                 Opcode::Mvvw.get_field_elt(),
                 dst.get_slot_16bfield_val(),
@@ -220,7 +226,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Mvvl { dst, src } => {
+        InstructionsWithLabels::Mvvl { dst, src, .. } => {
             let instruction = [
                 Opcode::Mvvl.get_field_elt(),
                 dst.get_slot_16bfield_val(),
@@ -329,7 +335,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Ldi { dst, imm } => {
+        InstructionsWithLabels::Ldi { dst, imm, .. } => {
             let instruction = [
                 Opcode::Ldi.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -340,7 +346,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Xor { dst, src1, src2 } => {
+        InstructionsWithLabels::Xor {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Xor.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -351,7 +359,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Xori { dst, src, imm } => {
+        InstructionsWithLabels::Xori { dst, src, imm, .. } => {
             let instruction = [
                 Opcode::Xori.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -382,7 +390,9 @@ pub fn get_prom_inst_from_inst_with_label(
             }
             *field_pc *= G;
         }
-        InstructionsWithLabels::Add { dst, src1, src2 } => {
+        InstructionsWithLabels::Add {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Add.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -393,7 +403,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Addi { dst, src1, imm } => {
+        InstructionsWithLabels::Addi { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::Addi.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -404,7 +414,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Or { dst, src1, src2 } => {
+        InstructionsWithLabels::Or {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Or.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -415,7 +427,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Ori { dst, src1, imm } => {
+        InstructionsWithLabels::Ori { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::Ori.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -426,7 +438,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sub { dst, src1, src2 } => {
+        InstructionsWithLabels::Sub {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Sub.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -437,7 +451,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sle { dst, src1, src2 } => {
+        InstructionsWithLabels::Sle {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Sle.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -448,7 +464,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Slei { dst, src, imm } => {
+        InstructionsWithLabels::Slei { dst, src, imm, .. } => {
             let instruction = [
                 Opcode::Slei.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -459,7 +475,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sleu { dst, src1, src2 } => {
+        InstructionsWithLabels::Sleu {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Sleu.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -470,7 +488,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sleiu { dst, src, imm } => {
+        InstructionsWithLabels::Sleiu { dst, src, imm, .. } => {
             let instruction = [
                 Opcode::Sleiu.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -481,7 +499,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Slt { dst, src1, src2 } => {
+        InstructionsWithLabels::Slt {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Slt.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -492,7 +512,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Slti { dst, src, imm } => {
+        InstructionsWithLabels::Slti { dst, src, imm, .. } => {
             let instruction = [
                 Opcode::Slti.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -503,7 +523,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sltu { dst, src1, src2 } => {
+        InstructionsWithLabels::Sltu {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Sltu.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -514,7 +536,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sltiu { dst, src, imm } => {
+        InstructionsWithLabels::Sltiu { dst, src, imm, .. } => {
             let instruction = [
                 Opcode::Sltiu.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -525,7 +547,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sll { dst, src1, src2 } => {
+        InstructionsWithLabels::Sll {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Sll.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -536,7 +560,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Srl { dst, src1, src2 } => {
+        InstructionsWithLabels::Srl {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Srl.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -547,7 +573,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Sra { dst, src1, src2 } => {
+        InstructionsWithLabels::Sra {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Sra.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -558,7 +586,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Andi { dst, src1, imm } => {
+        InstructionsWithLabels::Andi { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::Andi.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -570,7 +598,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::And { dst, src1, src2 } => {
+        InstructionsWithLabels::And {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::And.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -582,7 +612,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Muli { dst, src1, imm } => {
+        InstructionsWithLabels::Muli { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::Muli.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -593,7 +623,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Mul { dst, src1, src2 } => {
+        InstructionsWithLabels::Mul {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Mul.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -604,7 +636,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Mulu { dst, src1, src2 } => {
+        InstructionsWithLabels::Mulu {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Mulu.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -615,7 +649,9 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Mulsu { dst, src1, src2 } => {
+        InstructionsWithLabels::Mulsu {
+            dst, src1, src2, ..
+        } => {
             let instruction = [
                 Opcode::Mulsu.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -626,7 +662,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Srli { dst, src1, imm } => {
+        InstructionsWithLabels::Srli { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::Srli.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -637,7 +673,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Slli { dst, src1, imm } => {
+        InstructionsWithLabels::Slli { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::Slli.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -648,7 +684,7 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
-        InstructionsWithLabels::Srai { dst, src1, imm } => {
+        InstructionsWithLabels::Srai { dst, src1, imm, .. } => {
             let instruction = [
                 Opcode::Srai.get_field_elt(),
                 dst.get_16bfield_val(),
@@ -670,6 +706,8 @@ pub fn get_prom_inst_from_inst_with_label(
 
             *field_pc *= G;
         }
+        InstructionsWithLabels::Alloci { .. } => unimplemented!(),
+        InstructionsWithLabels::Allocv { .. } => unimplemented!(),
     }
     Ok(())
 }

--- a/assembly/src/parser/asm.pest
+++ b/assembly/src/parser/asm.pest
@@ -54,10 +54,12 @@ TAILI_instr    = { "TAILI" }
 BNZ_instr      = { "BNZ" }
 CALLV_instr    = { "CALLV" }
 TAILV_instr    = { "TAILV" }
+ALLOCI_instr   = { "ALLOCI" }
+ALLOCV_instr   = { "ALLOCV" }
 
 // Note: This does not refer to BinaryFields but instructions that takes in three operands including destination
 binary_non_imm_instrs = ${
-    XOR_instr
+  ( XOR_instr
   | B32_ADD_instr
   | B32_MUL_instr
   | B128_ADD_instr
@@ -75,10 +77,10 @@ binary_non_imm_instrs = ${
   | SRA_instr
   | MULSU_instr
   | MULU_instr
-  | MUL_instr
+  | MUL_instr ) ~ prover_flag?
 }
 binary_imm_instrs     = ${
-    XORI_instr
+  ( XORI_instr
   | B32_ADDI_instr
   | B32_MULI_instr
   | ADDI_instr
@@ -91,12 +93,14 @@ binary_imm_instrs     = ${
   | SLLI_instr
   | SRLI_instr
   | SRAI_instr
-  | MULI_instr
+  | MULI_instr ) ~ prover_flag?
 }
-load_store_instrs     = ${ LW_instr | SW_instr | LBU_instr | LB_instr | LHU_instr | LH_instr | SB_instr | SH_instr }
-mov_non_imm_instrs    = ${ MVV_W_instr | MVV_L_instr }
-mov_imm_instr         = ${ MVI_H_instr }
-load_imm_instr        = ${ LDI_W_instr }
+load_store_instrs     = ${ (LW_instr | SW_instr | LBU_instr | LB_instr | LHU_instr | LH_instr | SB_instr | SH_instr) ~ prover_flag? }
+mov_non_imm_instrs    = ${ (MVV_W_instr | MVV_L_instr) ~ prover_flag? }
+mov_imm_instr         = ${ MVI_H_instr ~ prover_flag? }
+load_imm_instr        = ${ LDI_W_instr ~ prover_flag? }
+alloc_imm_instr       = ${ ALLOCI_instr ~ prover_flag }
+alloc_non_imm_instr   = ${ ALLOCV_instr ~ prover_flag }
 nullary_instrs        = ${ RET_instr }
 
 // Since these need to support labels, we need to handle them separately, the compiler handles immediate vs offsetted
@@ -117,6 +121,8 @@ COMMENT = _{ ";;" ~ (!NEWLINE ~ ANY)* }
 // Currently, this allows us to specify immediates as integers as well as generator constants ending with "G"
 immediate = @{ "#" ~ "-"? ~ (ASCII_DIGIT)+ ~ ("G")? }
 
+prover_flag    = @{ "!" }
+
 slot_or_offset = @{ ASCII_DIGIT+ }
 slot           = @{ "@" ~ slot_or_offset }
 
@@ -132,6 +138,8 @@ mov_imm              = ${ mov_imm_instr ~ spaces+ ~ slot_with_offset ~ separator
 mov_non_imm          = ${ mov_non_imm_instrs ~ spaces+ ~ slot_with_offset ~ separator ~ slot }
 load_imm             = ${ load_imm_instr ~ spaces+ ~ slot ~ separator ~ immediate }
 load_store           = ${ load_store_instrs ~ spaces+ ~ slot ~ separator ~ slot ~ separator ~ immediate }
+alloc_imm            = ${ alloc_imm_instr ~ spaces+ ~ slot ~ separator ~ immediate }
+alloc_non_imm        = ${ alloc_non_imm_instr ~ spaces+ ~ slot ~ separator ~ slot }
 
 instruction = {
     nullary
@@ -144,6 +152,8 @@ instruction = {
   | mov_non_imm
   | load_imm
   | load_store
+  | alloc_imm
+  | alloc_non_imm
 }
 
 line = { (((frame_size_annotation? ~ label ~ instruction?) | instruction) ~ COMMENT?) | COMMENT }

--- a/assembly/src/parser/instructions_with_labels.rs
+++ b/assembly/src/parser/instructions_with_labels.rs
@@ -15,33 +15,40 @@ pub enum InstructionsWithLabels {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     B32Muli {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     B128Add {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     B128Mul {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Mvih {
         dst: SlotWithOffset,
         imm: Immediate,
+        prover_only: bool,
     },
     Mvvw {
         dst: SlotWithOffset,
         src: Slot,
+        prover_only: bool,
     },
     Mvvl {
         dst: SlotWithOffset,
         src: Slot,
+        prover_only: bool,
     },
     Taili {
         label: String,
@@ -68,16 +75,19 @@ pub enum InstructionsWithLabels {
     Ldi {
         dst: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Xor {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Xori {
         dst: Slot,
         src: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Bnz {
         label: String,
@@ -87,229 +97,372 @@ pub enum InstructionsWithLabels {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Addi {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Or {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Ori {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Sub {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Sle {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Slei {
         dst: Slot,
         src: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Sleu {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Sleiu {
         dst: Slot,
         src: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Slt {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Slti {
         dst: Slot,
         src: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Sltu {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Sltiu {
         dst: Slot,
         src: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Sll {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Srl {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Sra {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Andi {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     And {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Muli {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Mul {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Mulu {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Mulsu {
         dst: Slot,
         src1: Slot,
         src2: Slot,
+        prover_only: bool,
     },
     Srli {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Slli {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
     },
     Srai {
         dst: Slot,
         src1: Slot,
         imm: Immediate,
+        prover_only: bool,
+    },
+    Alloci {
+        dst: Slot,
+        imm: Immediate,
+    },
+    Allocv {
+        dst: Slot,
+        src: Slot,
     },
     Ret,
 }
 
+impl InstructionsWithLabels {
+    fn prover_only(&self) -> bool {
+        use InstructionsWithLabels::*;
+        match self {
+            B32Mul { prover_only, .. } => *prover_only,
+            B32Muli { prover_only, .. } => *prover_only,
+            B128Add { prover_only, .. } => *prover_only,
+            B128Mul { prover_only, .. } => *prover_only,
+            Mvih { prover_only, .. } => *prover_only,
+            Mvvw { prover_only, .. } => *prover_only,
+            Mvvl { prover_only, .. } => *prover_only,
+            Ldi { prover_only, .. } => *prover_only,
+            Xor { prover_only, .. } => *prover_only,
+            Xori { prover_only, .. } => *prover_only,
+            Add { prover_only, .. } => *prover_only,
+            Addi { prover_only, .. } => *prover_only,
+            Or { prover_only, .. } => *prover_only,
+            Ori { prover_only, .. } => *prover_only,
+            Sub { prover_only, .. } => *prover_only,
+            Sle { prover_only, .. } => *prover_only,
+            Slei { prover_only, .. } => *prover_only,
+            Sleu { prover_only, .. } => *prover_only,
+            Sleiu { prover_only, .. } => *prover_only,
+            Slt { prover_only, .. } => *prover_only,
+            Slti { prover_only, .. } => *prover_only,
+            Sltu { prover_only, .. } => *prover_only,
+            Sltiu { prover_only, .. } => *prover_only,
+            Sll { prover_only, .. } => *prover_only,
+            Srl { prover_only, .. } => *prover_only,
+            Sra { prover_only, .. } => *prover_only,
+            Andi { prover_only, .. } => *prover_only,
+            And { prover_only, .. } => *prover_only,
+            Muli { prover_only, .. } => *prover_only,
+            Mul { prover_only, .. } => *prover_only,
+            Mulu { prover_only, .. } => *prover_only,
+            Mulsu { prover_only, .. } => *prover_only,
+            Srli { prover_only, .. } => *prover_only,
+            Slli { prover_only, .. } => *prover_only,
+            Srai { prover_only, .. } => *prover_only,
+            Alloci { .. } => true,
+            Allocv { .. } => true,
+            _ => false,
+        }
+    }
+}
+
 impl std::fmt::Display for InstructionsWithLabels {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use InstructionsWithLabels::*;
+        let bang = if self.prover_only() { "!" } else { "" };
         match self {
-            InstructionsWithLabels::Label(label, frame_size) => {
+            Label(label, frame_size) => {
                 if let Some(size) = frame_size {
                     write!(f, "#[framesize(0x{size:x})]\n{label}:")
                 } else {
                     write!(f, "{label}:")
                 }
             }
-            InstructionsWithLabels::B32Mul { dst, src1, src2 } => {
-                write!(f, "B32_MUL {dst} {src1} {src2}")
+            B32Mul {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "B32_MUL{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::B32Muli { dst, src1, imm } => {
-                write!(f, "B32_MULI {dst} {src1} {imm}")
+            B32Muli { dst, src1, imm, .. } => {
+                write!(f, "B32_MULI{bang} {dst} {src1} {imm}")
             }
-            InstructionsWithLabels::B128Add { dst, src1, src2 } => {
-                write!(f, "B128_ADD {dst} {src1} {src2}")
+            B128Add {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "B128_ADD{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::B128Mul { dst, src1, src2 } => {
-                write!(f, "B128_MUL {dst} {src1} {src2}")
+            B128Mul {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "B128_MUL{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Mvih { dst, imm } => write!(f, "MVI.H {dst} {imm}"),
-            InstructionsWithLabels::Mvvw { dst, src } => write!(f, "MVV.W {dst} {src}"),
-            InstructionsWithLabels::Mvvl { dst, src } => write!(f, "MVV.L {dst} {src}"),
-            InstructionsWithLabels::Taili { label, next_fp } => {
+            Mvih { dst, imm, .. } => {
+                write!(f, "MVI.H{bang} {dst} {imm}")
+            }
+            Mvvw { dst, src, .. } => {
+                write!(f, "MVV.W{bang} {dst} {src}")
+            }
+            Mvvl { dst, src, .. } => {
+                write!(f, "MVV.L{bang} {dst} {src}")
+            }
+            Taili { label, next_fp } => {
                 write!(f, "TAILI {label} {next_fp}")
             }
-            InstructionsWithLabels::Tailv { offset, next_fp } => {
+            Tailv { offset, next_fp } => {
                 write!(f, "TAILV {offset} {next_fp}")
             }
-            InstructionsWithLabels::Calli { label, next_fp } => {
+            Calli { label, next_fp } => {
                 write!(f, "CALLI {label} {next_fp}")
             }
-            InstructionsWithLabels::Callv { offset, next_fp } => {
+            Callv { offset, next_fp } => {
                 write!(f, "CALLV {offset} {next_fp}")
             }
-            InstructionsWithLabels::Jumpi { label } => write!(f, "JUMPI {label}"),
-            InstructionsWithLabels::Jumpv { offset } => write!(f, "JUMPV {offset}"),
-            InstructionsWithLabels::Ldi { dst, imm } => write!(f, "LDI {dst} {imm}"),
-            InstructionsWithLabels::Xor { dst, src1, src2 } => write!(f, "XOR {dst} {src1} {src2}"),
-            InstructionsWithLabels::Xori { dst, src, imm } => write!(f, "XORI {dst} {src} {imm}"),
-            InstructionsWithLabels::Bnz { label, src } => write!(f, "BNZ {label} {src}"),
-            InstructionsWithLabels::Add { dst, src1, src2 } => write!(f, "ADD {dst} {src1} {src2}"),
-            InstructionsWithLabels::Addi { dst, src1, imm } => write!(f, "ADDI {dst} {src1} {imm}"),
-            InstructionsWithLabels::Or { dst, src1, src2 } => write!(f, "OR {dst} {src1} {src2}"),
-            InstructionsWithLabels::Ori { dst, src1, imm } => {
-                write!(f, "ORI {dst} {src1} {imm}")
+            Jumpi { label } => write!(f, "J {label}"),
+            Jumpv { offset } => write!(f, "J {offset}"),
+            Ldi { dst, imm, .. } => write!(f, "LDI{bang} {dst} {imm}"),
+            Xor {
+                dst, src1, src2, ..
+            } => write!(f, "XOR{bang} {dst} {src1} {src2}"),
+            Xori { dst, src, imm, .. } => {
+                write!(f, "XORI{bang} {dst} {src} {imm}")
             }
-            InstructionsWithLabels::Sub { dst, src1, src2 } => write!(f, "SUB {dst} {src1} {src2}"),
-            InstructionsWithLabels::Sle { dst, src1, src2 } => {
-                write!(f, "SLE {dst} {src1} {src2}")
+            Bnz { label, src } => write!(f, "BNZ {label} {src}"),
+            Add {
+                dst, src1, src2, ..
+            } => write!(f, "ADD{bang} {dst} {src1} {src2}"),
+            Addi { dst, src1, imm, .. } => {
+                write!(f, "ADDI{bang} {dst} {src1} {imm}")
             }
-            InstructionsWithLabels::Slei { dst, src, imm } => {
-                write!(f, "SLEI {dst} {src} {imm}")
+            Or {
+                dst, src1, src2, ..
+            } => write!(f, "OR{bang} {dst} {src1} {src2}"),
+            Ori { dst, src1, imm, .. } => {
+                write!(f, "ORI{bang} {dst} {src1} {imm}")
             }
-            InstructionsWithLabels::Sleu { dst, src1, src2 } => {
-                write!(f, "SLEU {dst} {src1} {src2}")
+            Sub {
+                dst, src1, src2, ..
+            } => write!(f, "SUB{bang} {dst} {src1} {src2}"),
+            Sle {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "SLE{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Sleiu { dst, src, imm } => {
-                write!(f, "SLEIU {dst} {src} {imm}")
+            Slei { dst, src, imm, .. } => {
+                write!(f, "SLEI{bang} {dst} {src} {imm}")
             }
-            InstructionsWithLabels::Slt { dst, src1, src2 } => {
-                write!(f, "SLT {dst} {src1} {src2}")
+            Sleu {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "SLEU{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Slti { dst, src, imm } => {
-                write!(f, "SLTI {dst} {src} {imm}")
+            Sleiu { dst, src, imm, .. } => {
+                write!(f, "SLEIU{bang} {dst} {src} {imm}")
             }
-            InstructionsWithLabels::Sltu { dst, src1, src2 } => {
-                write!(f, "SLTU {dst} {src1} {src2}")
+            Slt {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "SLT{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Sltiu { dst, src, imm } => {
-                write!(f, "SLTIU {dst} {src} {imm}")
+            Slti { dst, src, imm, .. } => {
+                write!(f, "SLTI{bang} {dst} {src} {imm}")
             }
-            InstructionsWithLabels::Sll { dst, src1, src2 } => {
-                write!(f, "SLL {dst} {src1} {src2}")
+            Sltu {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "SLTU{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Srl { dst, src1, src2 } => {
-                write!(f, "SRL {dst} {src1} {src2}")
+            Sltiu { dst, src, imm, .. } => {
+                write!(f, "SLTIU{bang} {dst} {src} {imm}")
             }
-            InstructionsWithLabels::Sra { dst, src1, src2 } => {
-                write!(f, "SRA {dst} {src1} {src2}")
+            Sll {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "SLL{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Andi { dst, src1, imm } => write!(f, "ANDI {dst} {src1} {imm}"),
-            InstructionsWithLabels::And { dst, src1, src2 } => {
-                write!(f, "AND {dst} {src1} {src2}")
+            Srl {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "SRL{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Muli { dst, src1, imm } => write!(f, "MULI {dst} {src1} {imm}"),
-            InstructionsWithLabels::Mul { dst, src1, src2 } => write!(f, "MUL {dst} {src1} {src2}"),
-            InstructionsWithLabels::Mulu { dst, src1, src2 } => {
-                write!(f, "MULU {dst} {src1} {src2}")
+            Sra {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "SRA{bang} {dst} {src1} {src2}")
             }
-            InstructionsWithLabels::Mulsu { dst, src1, src2 } => {
-                write!(f, "MULSU {dst} {src1} {src2}")
+            Andi { dst, src1, imm, .. } => {
+                write!(f, "ANDI{bang} {dst} {src1} {imm}")
             }
-            InstructionsWithLabels::Srli { dst, src1, imm } => write!(f, "SRLI {dst} {src1} {imm}"),
-            InstructionsWithLabels::Slli { dst, src1, imm } => write!(f, "SLLI {dst} {src1} {imm}"),
-            InstructionsWithLabels::Srai { dst, src1, imm } => write!(f, "SRAI {dst} {src1} {imm}"),
-            InstructionsWithLabels::Ret => write!(f, "RET"),
+            And {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "AND{bang} {dst} {src1} {src2}")
+            }
+            Muli { dst, src1, imm, .. } => {
+                write!(f, "MULI{bang} {dst} {src1} {imm}")
+            }
+            Mul {
+                dst, src1, src2, ..
+            } => write!(f, "MUL{bang} {dst} {src1} {src2}"),
+            Mulu {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "MULU{bang} {dst} {src1} {src2}")
+            }
+            Mulsu {
+                dst, src1, src2, ..
+            } => {
+                write!(f, "MULSU{bang} {dst} {src1} {src2}")
+            }
+            Srli { dst, src1, imm, .. } => {
+                write!(f, "SRLI{bang} {dst} {src1} {imm}")
+            }
+            Slli { dst, src1, imm, .. } => {
+                write!(f, "SLLI{bang} {dst} {src1} {imm}")
+            }
+            Srai { dst, src1, imm, .. } => {
+                write!(f, "SRAI{bang} {dst} {src1} {imm}")
+            }
+            Ret => write!(f, "RET"),
+            Alloci { dst, imm } => {
+                write!(f, "ALLOCI! {dst} {imm}")
+            }
+            Allocv { dst, src } => {
+                write!(f, "ALLOCV! {dst} {src}")
+            }
         }
     }
 }

--- a/assembly/src/parser/tests.rs
+++ b/assembly/src/parser/tests.rs
@@ -105,6 +105,11 @@ mod test_parser {
     }
 
     #[test]
+    fn test_prover_flag() {
+        parse_program(include_str!("../../../examples/bezout_deterministic.asm")).unwrap();
+    }
+
+    #[test]
     fn test_all_instructions() {
         let lines = [
             "#[framesize(0x1a)] label:",

--- a/examples/bezout_deterministic.asm
+++ b/examples/bezout_deterministic.asm
@@ -1,0 +1,38 @@
+;; slot layout mimics the original non-deterministic bezout example
+#[framesize(0x3)]
+entrypoint:
+    ;; here we assume that entrypoint has dummy zero FP & PC frame
+    ALLOCI! @2, #15
+    MVI.H @2[2], #274
+    MVI.H @2[3], #685
+    MVI.H @2[4], #137
+    MVI.H @2[5], #-2
+    MVI.H @2[6], #1
+    CALLI bezout, @2
+    RET
+bezout:
+    BNZ bezout_else, @2
+    XORI @4, @3, #0
+    LDI.W @5, #0
+    LDI.W @6, #1
+    RET
+bezout_else:
+    ;; contrived, @13/@14 are not in VROM assignment
+    LDI.W! @13, #7
+    ADDI! @14, @13, #3
+    ALLOCV! @7, @14
+    MVV.W @7[2], @3
+    MVV.W @7[3], @2
+    MVV.W @7[4], @9
+    MVV.W @7[5], @10
+    CALLI div, @7
+    ALLOCI! @8, #15
+    MVV.W @8[2], @10
+    MVV.W @8[3], @2
+    MVV.W @8[4], @4
+    MVV.W @8[5], @6
+    MVV.W @8[6], @11
+    CALLI bezout, @8
+    MUL @12, @6, @9
+    SUB @5, @11, @12
+    RET


### PR DESCRIPTION
This PR augments the parser with the support of "prover view" instructions (those that come with a `!` bang at the end of their opcode and are intended for the emulator, not the prover). The boolean field `prover_only` has been added to the `InstructionWithLabel` clauses where applicable (all instructions besides conditionals, jumps/calls and allocations).