### PR TITLE
fix: structured column iface

### DIFF
--- a/prover/src/memory.rs
+++ b/prover/src/memory.rs
@@ -301,7 +301,8 @@ impl VromAddrSpaceTable {
         table.require_power_of_two_size();
 
         // Add column for address
-        let addr = table.add_structured::<B32>("addr", StructuredDynSize::Incrementing);
+        let addr = table
+            .add_structured::<B32>("addr", StructuredDynSize::Incrementing { max_size_log: 32 });
 
         // Push to VROM address space channel
         table.push(channels.vrom_addr_space_channel, [addr]);


### PR DESCRIPTION
In some recent binius change (https://github.com/IrreducibleOSS/binius/commit/30342d0c1115a4e09b4fcb2a74ca908abcad78d4) we changed the definition of the strcutured column. Now, it takes the maximum size as a base-2 logarithm. See the commit and the linked issue for more details.

