### PR TITLE
add init_logger guard for fibonacci example 

### DIFF
--- a/prover/examples/fibonacci.rs
+++ b/prover/examples/fibonacci.rs
@@ -15,7 +15,7 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    petravm_asm::init_logger();
+    let _guard = petravm_asm::init_logger();
 
     let res = fibonacci(args.n);
 


### PR DESCRIPTION
We need it for Perfetto traces to work correctly.