### PR TITLE
CI: Add benchmark workflow

### DIFF
--- a/.github/scripts/upload_perfetto_traces.py
+++ b/.github/scripts/upload_perfetto_traces.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import os
+import glob
+import subprocess
+import urllib.parse
+import datetime
+import argparse
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Upload Perfetto traces to S3 and append links to the GitHub summary."
+    )
+    p.add_argument("--perfetto-host", required=True, help="Base URL of your Perfetto host")
+    p.add_argument("--s3-bucket",     required=True, help="Your S3 bucket URL (e.g. s3://my-bucket)")
+    p.add_argument("--repo",          required=True, help="Repository name without owner/org prefix")
+    p.add_argument("--branch",        required=True, help="Branch name")
+    p.add_argument("--commit-sha",    required=True, help="Commit SHA")
+    p.add_argument("--results-dir",   required=True, help="Top-level directory where .perfetto-trace files live")
+    p.add_argument("--summary-path",  required=True, help="Path to GitHub summary file")
+    return p.parse_args()
+
+def main():
+    args = parse_args()
+
+    # sanitize inputs
+    branch = args.branch.replace("/", "-")
+    commit_sha_short = args.commit_sha[:7]
+    now_utc = datetime.datetime.now(datetime.timezone.utc)
+    run_dir = f"{now_utc:%Y-%m-%d_%H-%M-%S}-{commit_sha_short}"
+
+    traces_by_benchmark = {}
+
+    pattern = os.path.join(args.results_dir, "**", "*.perfetto-trace")
+    for file_path in sorted(glob.glob(pattern, recursive=True)):
+        file_name = os.path.basename(file_path)
+        machine = os.path.basename(os.path.dirname(file_path)).removeprefix("perfetto-traces-")
+        benchmark, mode, _, run_id, _ = file_name.split("-", 4)
+        thread  = f"{mode}-thread"
+
+        s3_key = f"traces/{args.repo}/{branch}/{benchmark}/{thread}/{machine}/{run_dir}/{machine}-{file_name}"
+        s3_dest = f"{args.s3_bucket}/{s3_key}"
+        subprocess.run(["aws", "s3", "cp", file_path, s3_dest], check=True)
+
+        trace_binary_url = f"{args.perfetto_host}/{s3_key}"
+        perfetto_ui_url = f"{args.perfetto_host}/#!/?url={urllib.parse.quote_plus(trace_binary_url)}"
+
+        label = f"{benchmark} ({thread}) on {machine}"
+        link = f"<a href='{perfetto_ui_url}' target='_blank'>#{run_id}</a>"
+        traces_by_benchmark.setdefault(benchmark, {}).setdefault(label, []).append(link)
+
+    # append to GitHub summary
+    with open(args.summary_path, "a") as summary:
+        summary.write("## 📊 Perfetto Traces\n")
+        for benchmark, groups in traces_by_benchmark.items():
+            summary.write(f"<details><summary>{benchmark}</summary>\n<ul>\n")
+            for label, links in groups.items():
+                summary.write(f"<li>{label}: " + " ".join(links) + "</li>\n")
+            summary.write("</ul>\n</details>\n")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,84 @@
+---
+
+name: Benchmark
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:  # Manual trigger
+    inputs:
+      benchmark:
+        description: "Benchmark to run (choose a specific benchmark or 'all')"
+        type: choice
+        options: [all, fibonacci]
+        default: all
+jobs:
+  #
+  # Run benchmarks
+  #
+  benchmark:
+    name: Run benchmarks (${{ matrix.os }})
+    container: rustlang/rust:nightly
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # make sure one matrix‐fail doesn’t stop the others
+      matrix:
+        os: [c7a-2xlarge, c8g-2xlarge, supermicro]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history to include all git information in traces
+      - name: Set safe directory
+        # workaround: https://github.com/actions/checkout/issues/2031
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Execute Benchmarks
+        run: |
+          ./scripts/run_benchmark.py \
+          --clean \
+          --output-dir benchmark_results \
+          --benchmark "${{ github.event.inputs.benchmark || 'all' }}"
+      - name: Store Perfetto Traces
+        uses: actions/upload-artifact@v4
+        with:
+          name: perfetto-traces-${{ matrix.os }}
+          path: benchmark_results/*.perfetto-trace
+
+  #
+  # Upload Perfetto Traces to S3
+  #
+  upload_perfetto_traces:
+    name: Upload Perfetto Traces to S3
+    permissions:
+      contents: read  # allow reading repository contents
+      id-token: write  # Required to get AWS credentials with OIDC
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Download Prefetto Traces
+        uses: actions/download-artifact@v4
+        with:
+          pattern: perfetto-traces-*
+          path: benchmark_results  # directory for artifacts
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.BENCHMARK_AWS_UPLOAD_ROLE }}
+      - name: Upload Perfetto Traces
+        run: |
+          python3 .github/scripts/upload_perfetto_traces.py \
+            --perfetto-host  "https://perfetto.irreducible.com" \
+            --s3-bucket      "${{ secrets.BENCHMARK_S3_BUCKET }}" \
+            --repo           "petravm" \
+            --branch         "${{ github.head_ref || github.ref_name }}" \
+            --commit-sha     "${{ github.sha }}" \
+            --results-dir    "benchmark_results" \
+            --summary-path   "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Cargo.lock
 
 /*.perfetto-trace
 .last_perfetto_trace_path
+benchmark_results

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ RUSTFLAGS="-C target-cpu=native" cargo run --release --example fibonacci -- -n 1
 RUSTFLAGS="-C target-cpu=native" cargo run --release --example collatz -- -n 7
 ```
 
+### Benchmarking examples
+
+Benchmarks are run on every commit to `main` across multiple machines, with detailed Perfetto traces collected for deep profiling.
+
+See the full [benchmark results](https://github.com/PetraProver/PetraVM/blob/main/.github/workflows/benchmark.yml).
+
 ## Development Status
 
 The project is actively developed. Many instructions are already supported by the prover, with new instructions and additional features added regularly.

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+from typing import Any, List, Dict, Optional
+from dataclasses import dataclass, field
+import argparse
+from pathlib import Path
+import subprocess
+import os
+import sys
+import time
+
+#
+# Benchmark Config
+#
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """
+    Configuration for a single benchmark.
+    """
+    name: str
+    display: str
+    args: List[str]
+    n_ops: int
+    single_threaded: bool = False
+
+
+# Note: Every benchmark is multi-threaded by default. On top of that it can be run in single-threaded mode.
+#  ┌──── name ───┬────── display ───────┬───────────────────── args ─────────────────────┬─ n_ops ─┬─ single_threaded ─┐
+_RAW_BENCH_ROWS = [
+  ("fibonacci",  "fibonacci",           ["fibonacci", "--", "--n"],                          100000,   True),
+]
+
+BENCHMARKS = {
+    name: BenchmarkConfig(name, display, args, n_ops, single_threaded)
+    for name, display, args, n_ops, single_threaded in _RAW_BENCH_ROWS
+}
+
+
+#
+# Parse Script Arguments
+#
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run one benchmark example multiple times"
+    )
+    parser.add_argument(
+        "--benchmark", "-b",
+        choices=list(BENCHMARKS.keys()) + ["all"],
+        default="all",
+        help="Which benchmark to run (default: all)",
+    )
+    parser.add_argument(
+        "--output-dir", "-o",
+        type=Path,
+        default=Path("benchmark_results"),
+        help="Directory to write CSVs & traces",
+    )
+    parser.add_argument(
+        "--samples", "-n",
+        type=int,
+        default=5,
+        help="How many times to repeat the benchmark",
+    )
+    parser.add_argument(
+        "--perfetto/--no-perfetto",
+        dest="perfetto",
+        default=True,
+        help="Whether to generate Perfetto traces",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Clean previous results for selected benchmarks before running",
+    )
+    return parser.parse_args()
+
+
+#
+# Execute a Benchmark
+#
+
+
+def run_single_benchmark(
+    name: str,
+    args: List[str],
+    n_ops: int,
+    outdir: Path,
+    samples: int = 5,
+    perfetto: bool = True,
+    multi_threaded: bool = True,
+) -> None:
+    """
+    Run one benchmark `samples` times.
+    Returns a dict mapping metric keys to lists of values.
+    """
+
+    mode = 'multi-thread' if multi_threaded else 'single-thread'
+
+    env = {
+        **os.environ,
+        'RAYON_NUM_THREADS': '0' if multi_threaded else '1',
+        'RUSTFLAGS': '-C target-cpu=native',
+    }
+
+    cmd = ['cargo', 'run', '--release', '--example'] + args + [str(n_ops)]
+
+    if perfetto:
+        env['PERFETTO_TRACE_DIR'] = str(outdir)
+        # Insert 'perfetto' feature args at index 3
+        cmd[3:3] = ['--features', 'perfetto']
+
+    # File containing the path to the last perfetto trace
+    trace_pointer = Path('.last_perfetto_trace_path')
+
+    for i in range(1, samples + 1):
+        # Prepare for next iteration
+        trace_pointer.unlink(missing_ok=True)
+
+        csv_result_path = outdir / f"{name}-{mode}-{i}.csv"
+        env['PROFILE_CSV_FILE'] = str(csv_result_path)
+        print(f"Running {name} ({mode}) sample #{i}")
+        print(f"{' '.join(cmd)}")
+
+        # Run the benchmark
+        proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        # Print a “heartbeat” while it’s running
+        last_dot = 0
+        while proc.poll() is None:
+            time.sleep(0.5)
+            if time.monotonic() - last_dot >= 5:
+                print('.', end='', flush=True)
+                last_dot = time.monotonic()
+
+        stdout, stderr = proc.communicate()
+
+        if proc.returncode != 0:
+            print(" failed")
+            print(stdout, end='')
+            print(stderr, file=sys.stderr, end='')
+            sys.exit(proc.returncode)
+        else:
+            print(" done")
+
+        # Post-run: Collect results and clean up
+        if perfetto:
+            # Rename Perfetto trace file
+            if not trace_pointer.exists():
+                raise RuntimeError("Perfetto trace file not found (missing .last_perfetto_trace_path)")
+            trace_path = Path(trace_pointer.read_text().strip())
+            if not trace_path.exists():
+                raise RuntimeError(f"Perfetto trace file not found: {trace_path} (read from .last_perfetto_trace_path)")
+            trace_pointer.unlink()
+
+            new_path = trace_path.parent / f"{name}-{mode}-{i}-{trace_path.name}"
+            trace_path.rename(new_path)
+
+        if not csv_result_path.exists():
+            raise RuntimeError(f"CSV result file not found: {csv_result_path}")
+
+#
+# Main
+#
+
+
+def main():
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Determine benchmarks to run
+    if args.benchmark == "all":
+        run_names = list(BENCHMARKS.keys())
+    else:
+        run_names = [args.benchmark]
+
+    # Clean previous result files if requested
+    if args.clean:
+        for benchmark_name in run_names:
+            prefix = f"{benchmark_name}-"
+            for f in args.output_dir.glob(f"{prefix}*"):
+                try:
+                    f.unlink()
+                except OSError:
+                    pass
+
+    # Run each benchmark and write its results
+    for benchmark_name in run_names:
+        cfg = BENCHMARKS[benchmark_name]
+
+        # Always run multi-threaded
+        run_single_benchmark(
+            name=cfg.name,
+            args=cfg.args,
+            n_ops=cfg.n_ops,
+            outdir=args.output_dir,
+            samples=args.samples,
+            perfetto=args.perfetto,
+            multi_threaded=True,
+        )
+        # Then, if configured, run single-threaded too
+        if cfg.single_threaded:
+            run_single_benchmark(
+                name=cfg.name,
+                args=cfg.args,
+                n_ops=cfg.n_ops,
+                outdir=args.output_dir,
+                samples=args.samples,
+                perfetto=args.perfetto,
+                multi_threaded=False,
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change introduces a new `Benchmark` workflow, along with `scripts/run_benchmark.py` script.

### scripts/run_benchmark.py

Helper script for running Rust example benchmarks: you pick a benchmark (like `fibonacci`), tell it how many times to run it, and where to save results. It automatically builds and executes each benchmark (in both multi- and single-threaded modes if enabled), and stores Perfetto traces as a result.

```bash
./scripts/run_benchmark.py \
  --benchmark fibonacci \
  --samples 10 \
  --output-dir ./benchmark_results \
  --perfetto
```

### Benchmark workflow

GitHub Actions workflow that starts on every push to the `main` branch or via manual trigger. It does two main things:

#### Run benchmarks

Spins up a matrix of machines (three instance types), and uses `scripts/run_benchmark.py` to run benchmarks, and stores perfetto traces as GitHub artifacts.

#### Uploads Perfetto Traces to s3

Uploads Perfetto Traces to s3 bucket, so they can be easily opened in Perfetto UI (under: https://perfetto.irreducible.com/traces.html).

Also writes summary to the execution, with links to all Perfetto Traces.

Tested here: https://github.com/PetraProver/PetraVM/actions/runs/15608725064