### PR TITLE
chore: update binius revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-profile = "0.10.6"
 
 # Binius dependencies
-binius_core = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
-binius_fast_compute = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
-binius_compute = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
-binius_field = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
-binius_hal = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
-binius_hash = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
-binius_m3 = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
-binius_utils = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
+binius_core = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
+binius_fast_compute = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
+binius_compute = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
+binius_field = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
+binius_hal = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
+binius_hash = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
+binius_m3 = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
+binius_utils = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742" }
 
 [profile.release]
 lto = "fat"

--- a/prover/src/circuit.rs
+++ b/prover/src/circuit.rs
@@ -4,11 +4,12 @@
 //! all the individual tables and channels.
 
 #[cfg(feature = "disable_state_channel")]
-use binius_m3::builder::{Boundary, ConstraintSystem, FlushDirection, Statement};
+use binius_m3::builder::{Boundary, ConstraintSystem, FlushDirection};
 #[cfg(not(feature = "disable_state_channel"))]
-use binius_m3::builder::{Boundary, ConstraintSystem, FlushDirection, Statement, B128};
+use binius_m3::builder::{Boundary, ConstraintSystem, FlushDirection, B128};
 use petravm_asm::isa::ISA;
 
+use crate::types::Statement;
 use crate::{
     channels::Channels,
     gadgets::right_shifter_table::RightShifterTable,

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -14,10 +14,11 @@ use binius_field::arch::OptimalUnderlier;
 use binius_field::tower::CanonicalTowerFamily;
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
-use binius_m3::builder::{Statement, WitnessIndex, B128};
+use binius_m3::builder::{WitnessIndex, B128};
 use petravm_asm::isa::ISA;
 use tracing::instrument;
 
+use crate::types::Statement;
 use crate::{circuit::Circuit, model::Trace, types::ProverPackedField};
 
 const LOG_INV_RATE: usize = 1;
@@ -101,11 +102,7 @@ impl Prover {
         let statement = self.circuit.create_statement(trace)?;
 
         // Compile the constraint system
-        let compiled_cs = self
-            .circuit
-            .cs
-            .compile(&statement)
-            .map_err(|e| anyhow!(e))?;
+        let compiled_cs = self.circuit.cs.compile().map_err(|e| anyhow!(e))?;
 
         let witness_allocator_span = tracing::info_span!("Witness Alloc").entered();
 

--- a/prover/src/types.rs
+++ b/prover/src/types.rs
@@ -5,7 +5,17 @@
 
 use binius_field::arch::OptimalUnderlier;
 use binius_field::as_packed_field::PackedType;
-use binius_m3::builder::B128;
+use binius_m3::builder::{Boundary, B128};
 
 /// The preferred packed field type used by the prover
 pub type ProverPackedField = PackedType<OptimalUnderlier, B128>;
+
+/// Statement describing the circuit instance for proving and verification.
+///
+/// This mirrors the struct that used to be provided by `binius_m3`.
+/// It simply bundles the channel boundaries together with the table sizes.
+#[derive(Debug, Clone)]
+pub struct Statement {
+    pub boundaries: Vec<Boundary<B128>>,
+    pub table_sizes: Vec<usize>,
+}


### PR DESCRIPTION
This is mostly provided by Codex.

Upgrades PetraVM to the latest version of binius including this breaking change https://github.com/IrreducibleOSS/binius/commit/f869c4ebd6d8ed7acdb3785ab66b8d9e1b130742 

I specifically picked the version that lifts `Statement` to petravm. This could be left as is or refactored away.