### PR TITLE
set lto to thin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ binius_m3 = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac4
 binius_utils = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2aac402f261a2b7fd59a563d97f5884087c15c6a" }
 
 [profile.release]
-lto = "fat"
+lto = "thin"


### PR DESCRIPTION
Running fibonnaci (n=100000).

LTO setting | Build time | Run time
-- | -- | --
fat (default) | ~2m34s | ~25.4s
thin | ~1m48s | ~25.4s
none | ~2m05s | ~2m04s

Related:
- https://github.com/PetraProver/PetraVM/pull/136
- https://github.com/IrreducibleOSS/binius/pull/759